### PR TITLE
feat: add email magic-link sign-in backed by the resident directory sheet

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,5 +1,10 @@
 # Copy to .dev.vars for local development (`pnpm preview` / `pnpm dev`).
-# In production, set these with `wrangler secret put <NAME>`.
+#
+# In production (Cloudflare Pages), set these in the Pages project:
+# dashboard -> Settings -> Environment variables (Production and Preview),
+# or `wrangler pages secret put <NAME> --project-name fcr-website`.
+# The Pages project also needs the `nodejs_compat` compatibility flag.
+# (For a Workers deployment, use `wrangler secret put <NAME>` instead.)
 
 # Random string used to sign magic-link tokens and session cookies.
 # Generate with: openssl rand -base64 32

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,22 @@
+# Copy to .dev.vars for local development (`pnpm preview` / `pnpm dev`).
+# In production, set these with `wrangler secret put <NAME>`.
+
+# Random string used to sign magic-link tokens and session cookies.
+# Generate with: openssl rand -base64 32
+AUTH_SECRET=""
+
+# Service account with read access to the resident directory sheet
+# (same account used by automation/directory.js).
+GOOGLE_SERVICE_ACCOUNT_EMAIL=""
+GOOGLE_PRIVATE_KEY=""
+
+# Spreadsheet ID of the resident directory.
+GOOGLE_SHEET_ID=""
+
+# Optional: A1 range of the directory table, defaults to A1:H.
+# GOOGLE_SHEET_RANGE="Sheet1!A1:H"
+
+# Resend (https://resend.com) API key for sending magic-link emails.
+# The fallscreekranch.org domain must be verified in Resend.
+RESEND_API_KEY=""
+EMAIL_FROM="Falls Creek Ranch <no-reply@fallscreekranch.org>"

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -7,6 +7,8 @@
 # (For a Workers deployment, use `wrangler secret put <NAME>` instead.)
 
 # Random string used to sign magic-link tokens and session cookies.
+# Must be at least 32 characters — a weak secret makes sessions and magic
+# links forgeable, so a short one is rejected at startup rather than used.
 # Generate with: openssl rand -base64 32
 AUTH_SECRET=""
 

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -20,8 +20,9 @@ GOOGLE_PRIVATE_KEY=""
 # Spreadsheet ID of the resident directory.
 GOOGLE_SHEET_ID=""
 
-# Optional: A1 range of the directory table, defaults to A1:H.
-# GOOGLE_SHEET_RANGE="Sheet1!A1:H"
+# Optional: where the addresses live. Defaults to "emails!A:A" — column A
+# of the `emails` tab. Only set this if the directory moves.
+# GOOGLE_SHEET_RANGE="emails!A:A"
 
 # Resend (https://resend.com) API key for sending magic-link emails.
 # The fallscreekranch.org domain must be verified in Resend.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,8 +140,12 @@ Residents can sign in at `/login` with just their email. The flow:
 
 1. `/login` (static page) posts the email to `POST /api/auth/request`
 2. The worker checks the email against the **resident directory Google Sheet**
-   (the one populated by `automation/directory.js`) via the Sheets REST API
-   using the same service account
+   via the Sheets REST API using the same service account. It reads only
+   `emails!A:A` (column A of the `emails` tab) by default, so the rest of
+   the residents' details never enter the Worker; `GOOGLE_SHEET_RANGE`
+   overrides it. The column is located by an "email" header when one is
+   present, falling back to the first column, and a header cell containing
+   "@" is treated as data so a headerless sheet keeps its first row.
 3. If found, a signed magic link (HMAC token, 30 min expiry) is emailed via
    **Resend**; the response is identical either way to prevent probing the
    directory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,8 +160,15 @@ Notes:
   `src/lib/directory.ts` implements the service-account JWT flow with WebCrypto.
 - Secrets (see `.dev.vars.example`): `AUTH_SECRET`,
   `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`, `GOOGLE_SHEET_ID`,
-  optional `GOOGLE_SHEET_RANGE`, `RESEND_API_KEY`, `EMAIL_FROM`. Set in
-  production with `wrangler secret put <NAME>`; locally in `.dev.vars`.
+  optional `GOOGLE_SHEET_RANGE`, `RESEND_API_KEY`, `EMAIL_FROM`. Locally
+  these go in `.dev.vars`. In production (Cloudflare Pages) set them as
+  environment variables on the Pages project (Production **and** Preview);
+  for a Workers deployment use `wrangler secret put <NAME>`.
+- The build works on both Cloudflare Pages and Workers: the adapter emits
+  `dist/_worker.js` plus `dist/_routes.json`, so Pages serves the static
+  site directly and routes only `/api/*` and `/members` through the worker.
+  The Pages project needs the `nodejs_compat` compatibility flag (Pages
+  does not read `wrangler.jsonc`).
 
 ## Static Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,35 @@ These charts are for **HOA members, not accountants**. Key principles:
 - `<details>/<summary>` blocks for collapsible archival content
 - Financial page (`governance/financial-insurance.mdx`) imports `FinancialCharts` component
 
+## Member Sign-In (Magic Links)
+
+Residents can sign in at `/login` with just their email. The flow:
+
+1. `/login` (static page) posts the email to `POST /api/auth/request`
+2. The worker checks the email against the **resident directory Google Sheet**
+   (the one populated by `automation/directory.js`) via the Sheets REST API
+   using the same service account
+3. If found, a signed magic link (HMAC token, 30 min expiry) is emailed via
+   **Resend**; the response is identical either way to prevent probing the
+   directory
+4. `GET /api/auth/verify?token=...` validates the token and sets a signed
+   `fcr_session` cookie (30 days)
+5. `src/middleware.ts` gates everything under `/members/` behind that cookie
+
+Key files: `src/lib/{tokens,session,directory,email,env}.ts`,
+`src/pages/api/auth/`, `src/pages/login.astro`, `src/pages/members/`.
+
+Notes:
+- Tokens are stateless (HMAC-SHA256, signed with `AUTH_SECRET`) — no KV or
+  database. Magic links are therefore reusable until they expire (30 min);
+  switch to a KV-backed nonce if one-time use is ever required.
+- The worker cannot use the `googleapis` npm package (too Node-dependent), so
+  `src/lib/directory.ts` implements the service-account JWT flow with WebCrypto.
+- Secrets (see `.dev.vars.example`): `AUTH_SECRET`,
+  `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`, `GOOGLE_SHEET_ID`,
+  optional `GOOGLE_SHEET_RANGE`, `RESEND_API_KEY`, `EMAIL_FROM`. Set in
+  production with `wrangler secret put <NAME>`; locally in `.dev.vars`.
+
 ## Static Files
 
 PDFs and documents go in `public/uploads/`:

--- a/src/lib/directory.ts
+++ b/src/lib/directory.ts
@@ -103,14 +103,26 @@ function locateEmails(rows: string[][]): { column: number; body: string[][] } {
 }
 
 /**
- * Returns true if the email appears in the directory sheet.
+ * Whether the address was found, and how many the sheet actually yielded.
+ * The count is what distinguishes "this person isn't a resident" from
+ * "we read the wrong range and saw nothing at all".
+ */
+export interface DirectoryLookup {
+  found: boolean;
+  scanned: number;
+  range: string;
+}
+
+/**
+ * Looks the email up in the directory sheet.
  */
 export async function isEmailInDirectory(
   env: AuthEnv,
   email: string,
-): Promise<boolean> {
+): Promise<DirectoryLookup> {
   const accessToken = await getAccessToken(env);
-  const range = encodeURIComponent(env.GOOGLE_SHEET_RANGE || DEFAULT_RANGE);
+  const configuredRange = env.GOOGLE_SHEET_RANGE || DEFAULT_RANGE;
+  const range = encodeURIComponent(configuredRange);
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${env.GOOGLE_SHEET_ID}/values/${range}`;
 
   const response = await fetch(url, {
@@ -122,9 +134,18 @@ export async function isEmailInDirectory(
   }
   const data = (await response.json()) as { values?: string[][] };
   const rows = data.values ?? [];
-  if (!rows.length) return false;
+  if (!rows.length) {
+    return { found: false, scanned: 0, range: configuredRange };
+  }
 
   const { column, body } = locateEmails(rows);
   const target = normalizeEmail(email);
-  return body.some((row) => normalizeEmail(row[column] ?? "") === target);
+  const addresses = body
+    .map((row) => normalizeEmail(row[column] ?? ""))
+    .filter(Boolean);
+  return {
+    found: addresses.includes(target),
+    scanned: addresses.length,
+    range: configuredRange,
+  };
 }

--- a/src/lib/directory.ts
+++ b/src/lib/directory.ts
@@ -1,15 +1,21 @@
 /**
  * Look up emails in the resident directory Google Sheet.
  *
- * The sheet has headers in row 1, including an "Email" column. This module reads it
- * with the same service account, but talks to the Sheets REST API directly
- * so it can run inside the Cloudflare Worker (the `googleapis` package is
- * too Node-dependent for that runtime).
+ * Reads with the same service account as `automation/`, but talks to the
+ * Sheets REST API directly so it can run inside the Cloudflare Worker (the
+ * `googleapis` package is too Node-dependent for that runtime).
  */
 import type { AuthEnv } from "./env";
 
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SHEETS_SCOPE = "https://www.googleapis.com/auth/spreadsheets.readonly";
+
+/**
+ * Where the addresses live: column A of the `emails` tab. Override with
+ * GOOGLE_SHEET_RANGE if the directory ever moves. Fetching one column
+ * keeps the rest of the residents' details out of the Worker entirely.
+ */
+const DEFAULT_RANGE = "emails!A:A";
 
 function base64UrlEncode(bytes: Uint8Array): string {
   let binary = "";
@@ -80,14 +86,31 @@ export function normalizeEmail(email: string): string {
 }
 
 /**
- * Returns true if the email appears in the directory sheet's "Email" column.
+ * Picks the column holding addresses. Prefers a header naming it, so a
+ * wider range still works, and falls back to the first column — which is
+ * the default range's only column.
+ *
+ * A header cell containing "@" is treated as data, not a header, so a
+ * sheet with no header row doesn't silently drop its first resident.
+ */
+function locateEmails(rows: string[][]): { column: number; body: string[][] } {
+  const headerColumn = rows[0].findIndex(
+    (cell) => cell.toLowerCase().includes("email") && !cell.includes("@"),
+  );
+  return headerColumn === -1
+    ? { column: 0, body: rows }
+    : { column: headerColumn, body: rows.slice(1) };
+}
+
+/**
+ * Returns true if the email appears in the directory sheet.
  */
 export async function isEmailInDirectory(
   env: AuthEnv,
   email: string,
 ): Promise<boolean> {
   const accessToken = await getAccessToken(env);
-  const range = encodeURIComponent(env.GOOGLE_SHEET_RANGE || "A1:H");
+  const range = encodeURIComponent(env.GOOGLE_SHEET_RANGE || DEFAULT_RANGE);
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${env.GOOGLE_SHEET_ID}/values/${range}`;
 
   const response = await fetch(url, {
@@ -99,16 +122,9 @@ export async function isEmailInDirectory(
   }
   const data = (await response.json()) as { values?: string[][] };
   const rows = data.values ?? [];
-  if (rows.length < 2) return false;
+  if (!rows.length) return false;
 
-  const headers = rows[0].map((h) => h.trim().toLowerCase());
-  const emailColumn = headers.indexOf("email");
-  if (emailColumn === -1) {
-    throw new Error('Directory sheet is missing an "Email" header column');
-  }
-
+  const { column, body } = locateEmails(rows);
   const target = normalizeEmail(email);
-  return rows
-    .slice(1)
-    .some((row) => normalizeEmail(row[emailColumn] ?? "") === target);
+  return body.some((row) => normalizeEmail(row[column] ?? "") === target);
 }

--- a/src/lib/directory.ts
+++ b/src/lib/directory.ts
@@ -67,6 +67,7 @@ async function getAccessToken(env: AuthEnv): Promise<string> {
       grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
       assertion: jwt,
     }),
+    signal: AbortSignal.timeout(10_000),
   });
   if (!response.ok) {
     throw new Error(`Google token request failed: ${response.status}`);
@@ -92,6 +93,7 @@ export async function isEmailInDirectory(
 
   const response = await fetch(url, {
     headers: { Authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(10_000),
   });
   if (!response.ok) {
     throw new Error(`Google Sheets request failed: ${response.status}`);

--- a/src/lib/directory.ts
+++ b/src/lib/directory.ts
@@ -1,8 +1,7 @@
 /**
  * Look up emails in the resident directory Google Sheet.
  *
- * The sheet is populated by `automation/directory.js` (synced from Buildium)
- * with headers in row 1, including an "Email" column. This module reads it
+ * The sheet has headers in row 1, including an "Email" column. This module reads it
  * with the same service account, but talks to the Sheets REST API directly
  * so it can run inside the Cloudflare Worker (the `googleapis` package is
  * too Node-dependent for that runtime).

--- a/src/lib/directory.ts
+++ b/src/lib/directory.ts
@@ -1,0 +1,113 @@
+/**
+ * Look up emails in the resident directory Google Sheet.
+ *
+ * The sheet is populated by `automation/directory.js` (synced from Buildium)
+ * with headers in row 1, including an "Email" column. This module reads it
+ * with the same service account, but talks to the Sheets REST API directly
+ * so it can run inside the Cloudflare Worker (the `googleapis` package is
+ * too Node-dependent for that runtime).
+ */
+import type { AuthEnv } from "./env";
+
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const SHEETS_SCOPE = "https://www.googleapis.com/auth/spreadsheets.readonly";
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function pemToDer(pem: string): Uint8Array {
+  const base64 = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/, "")
+    .replace(/-----END PRIVATE KEY-----/, "")
+    .replace(/\s+/g, "");
+  const binary = atob(base64);
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0));
+}
+
+async function getAccessToken(env: AuthEnv): Promise<string> {
+  const privateKeyPem = env.GOOGLE_PRIVATE_KEY.replace(/\\n/g, "\n");
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pemToDer(privateKeyPem) as unknown as ArrayBuffer,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+
+  const now = Math.floor(Date.now() / 1000);
+  const encoder = new TextEncoder();
+  const header = base64UrlEncode(
+    encoder.encode(JSON.stringify({ alg: "RS256", typ: "JWT" })),
+  );
+  const claims = base64UrlEncode(
+    encoder.encode(
+      JSON.stringify({
+        iss: env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
+        scope: SHEETS_SCOPE,
+        aud: TOKEN_URL,
+        iat: now,
+        exp: now + 3600,
+      }),
+    ),
+  );
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    encoder.encode(`${header}.${claims}`),
+  );
+  const jwt = `${header}.${claims}.${base64UrlEncode(new Uint8Array(signature))}`;
+
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: jwt,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Google token request failed: ${response.status}`);
+  }
+  const data = (await response.json()) as { access_token: string };
+  return data.access_token;
+}
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/**
+ * Returns true if the email appears in the directory sheet's "Email" column.
+ */
+export async function isEmailInDirectory(
+  env: AuthEnv,
+  email: string,
+): Promise<boolean> {
+  const accessToken = await getAccessToken(env);
+  const range = encodeURIComponent(env.GOOGLE_SHEET_RANGE || "A1:H");
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${env.GOOGLE_SHEET_ID}/values/${range}`;
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!response.ok) {
+    throw new Error(`Google Sheets request failed: ${response.status}`);
+  }
+  const data = (await response.json()) as { values?: string[][] };
+  const rows = data.values ?? [];
+  if (rows.length < 2) return false;
+
+  const headers = rows[0].map((h) => h.trim().toLowerCase());
+  const emailColumn = headers.indexOf("email");
+  if (emailColumn === -1) {
+    throw new Error('Directory sheet is missing an "Email" header column');
+  }
+
+  const target = normalizeEmail(email);
+  return rows
+    .slice(1)
+    .some((row) => normalizeEmail(row[emailColumn] ?? "") === target);
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,53 @@
+/**
+ * Magic-link email delivery via the Resend API.
+ *
+ * Resend is used because Cloudflare Workers cannot send SMTP directly and
+ * the Workers email binding only delivers to verified addresses on the
+ * zone. The `fallscreekranch.org` domain must be verified in Resend for
+ * the configured EMAIL_FROM address.
+ */
+import type { AuthEnv } from "./env";
+
+export async function sendMagicLinkEmail(
+  env: AuthEnv,
+  to: string,
+  link: string,
+): Promise<void> {
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: env.EMAIL_FROM,
+      to: [to],
+      subject: "Your Falls Creek Ranch sign-in link",
+      text: [
+        "Hello,",
+        "",
+        "Use the link below to sign in to the Falls Creek Ranch members area. It expires in 30 minutes.",
+        "",
+        link,
+        "",
+        "If you did not request this link, you can safely ignore this email.",
+      ].join("\n"),
+      html: `
+        <p>Hello,</p>
+        <p>Use the button below to sign in to the Falls Creek Ranch members area. The link expires in 30 minutes.</p>
+        <p>
+          <a href="${link}" style="display:inline-block;padding:10px 20px;background:#2f6f4f;color:#ffffff;text-decoration:none;border-radius:6px;">
+            Sign in to fallscreekranch.org
+          </a>
+        </p>
+        <p>Or copy this link into your browser:<br><a href="${link}">${link}</a></p>
+        <p>If you did not request this link, you can safely ignore this email.</p>
+      `,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Resend request failed: ${response.status} ${body}`);
+  }
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -15,6 +15,7 @@ export async function sendMagicLinkEmail(
 ): Promise<void> {
   const response = await fetch("https://api.resend.com/emails", {
     method: "POST",
+    signal: AbortSignal.timeout(10_000),
     headers: {
       Authorization: `Bearer ${env.RESEND_API_KEY}`,
       "Content-Type": "application/json",

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -23,27 +23,20 @@ export interface AuthEnv {
 }
 
 /**
- * Base for configuration problems. Callers fail closed on any of these,
- * since no amount of retrying fixes a secret an admin has to set.
+ * A deployment that isn't configured yet. Callers fail closed, since no
+ * amount of retrying fixes a secret an admin has to set.
+ *
+ * `keys` names every variable at fault, not just the first, and is safe
+ * to show the visitor: the names are not secrets, only the values are,
+ * and surfacing them turns "it doesn't work" into a one-line fix.
  */
-export class ConfigError extends Error {}
-
-/** A required secret is absent — the deployment isn't configured yet. */
-export class MissingConfigError extends ConfigError {
-  constructor(readonly key: string) {
-    super(`Missing required environment variable: ${key}`);
-    this.name = "MissingConfigError";
-  }
-}
-
-/** A secret is present but unusable, e.g. blank or too weak to sign with. */
-export class InvalidConfigError extends ConfigError {
+export class ConfigError extends Error {
   constructor(
-    readonly key: string,
-    reason: string,
+    readonly keys: string[],
+    readonly problems: string[],
   ) {
-    super(`Invalid environment variable ${key}: ${reason}`);
-    this.name = "InvalidConfigError";
+    super(`Environment not configured — ${problems.join("; ")}`);
+    this.name = "ConfigError";
   }
 }
 
@@ -72,19 +65,31 @@ export function getAuthEnv(locals: App.Locals): AuthEnv {
   >;
   const env: Record<string, string> = {};
 
+  // Every problem is collected rather than thrown on the first, so one
+  // look tells an admin everything to fix instead of one round per key.
+  const keys: string[] = [];
+  const problems: string[] = [];
+  const fault = (key: string, problem: string) => {
+    keys.push(key);
+    problems.push(`${key} ${problem}`);
+  };
+
   for (const key of REQUIRED_KEYS) {
     const value = raw[key];
     if (value === undefined || value === null || value === "") {
-      throw new MissingConfigError(key);
+      fault(key, "is not set");
+      continue;
     }
     if (typeof value !== "string") {
-      throw new InvalidConfigError(key, "expected a string");
+      fault(key, "is not a string");
+      continue;
     }
     // Trimmed because pasting into a dashboard field commonly picks up a
     // trailing newline, which would silently change the signing key.
     const trimmed = value.trim();
     if (!trimmed) {
-      throw new InvalidConfigError(key, "value is blank");
+      fault(key, "is blank");
+      continue;
     }
     env[key] = trimmed;
   }
@@ -92,11 +97,18 @@ export function getAuthEnv(locals: App.Locals): AuthEnv {
   // A short secret still produces valid HMACs — just guessable ones, which
   // would make session cookies and magic links forgeable. Fail loudly
   // rather than accept a weak key.
-  if (env.AUTH_SECRET.length < MIN_AUTH_SECRET_LENGTH) {
-    throw new InvalidConfigError(
+  if (
+    env.AUTH_SECRET !== undefined &&
+    env.AUTH_SECRET.length < MIN_AUTH_SECRET_LENGTH
+  ) {
+    fault(
       "AUTH_SECRET",
-      `must be at least ${MIN_AUTH_SECRET_LENGTH} characters; generate one with \`openssl rand -base64 32\``,
+      `is shorter than ${MIN_AUTH_SECRET_LENGTH} characters (generate one with \`openssl rand -base64 32\`)`,
     );
+  }
+
+  if (keys.length) {
+    throw new ConfigError(keys, problems);
   }
 
   return env as unknown as AuthEnv;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -22,6 +22,18 @@ export interface AuthEnv {
   EMAIL_FROM: string;
 }
 
+/**
+ * Thrown when a required secret is absent — i.e. the deployment has not
+ * been configured yet. Callers should fail closed but say something
+ * useful, since no amount of retrying will conjure the secret.
+ */
+export class MissingConfigError extends Error {
+  constructor(readonly key: string) {
+    super(`Missing required environment variable: ${key}`);
+    this.name = "MissingConfigError";
+  }
+}
+
 export function getAuthEnv(locals: App.Locals): AuthEnv {
   const runtime = (locals as { runtime?: { env?: Record<string, unknown> } })
     .runtime;
@@ -36,7 +48,7 @@ export function getAuthEnv(locals: App.Locals): AuthEnv {
     "EMAIL_FROM",
   ] as const) {
     if (!env[key]) {
-      throw new Error(`Missing required environment variable: ${key}`);
+      throw new MissingConfigError(key);
     }
   }
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -23,34 +23,81 @@ export interface AuthEnv {
 }
 
 /**
- * Thrown when a required secret is absent — i.e. the deployment has not
- * been configured yet. Callers should fail closed but say something
- * useful, since no amount of retrying will conjure the secret.
+ * Base for configuration problems. Callers fail closed on any of these,
+ * since no amount of retrying fixes a secret an admin has to set.
  */
-export class MissingConfigError extends Error {
+export class ConfigError extends Error {}
+
+/** A required secret is absent — the deployment isn't configured yet. */
+export class MissingConfigError extends ConfigError {
   constructor(readonly key: string) {
     super(`Missing required environment variable: ${key}`);
     this.name = "MissingConfigError";
   }
 }
 
+/** A secret is present but unusable, e.g. blank or too weak to sign with. */
+export class InvalidConfigError extends ConfigError {
+  constructor(
+    readonly key: string,
+    reason: string,
+  ) {
+    super(`Invalid environment variable ${key}: ${reason}`);
+    this.name = "InvalidConfigError";
+  }
+}
+
+/**
+ * Shortest AUTH_SECRET accepted. `openssl rand -base64 32` yields 44
+ * characters and `-hex 16` yields 32, so this admits the documented
+ * generators while rejecting a hand-typed passphrase.
+ */
+const MIN_AUTH_SECRET_LENGTH = 32;
+
+const REQUIRED_KEYS = [
+  "AUTH_SECRET",
+  "GOOGLE_SERVICE_ACCOUNT_EMAIL",
+  "GOOGLE_PRIVATE_KEY",
+  "GOOGLE_SHEET_ID",
+  "RESEND_API_KEY",
+  "EMAIL_FROM",
+] as const;
+
 export function getAuthEnv(locals: App.Locals): AuthEnv {
   const runtime = (locals as { runtime?: { env?: Record<string, unknown> } })
     .runtime;
-  const env = { ...import.meta.env, ...runtime?.env } as AuthEnv;
+  const raw = { ...import.meta.env, ...runtime?.env } as Record<
+    string,
+    unknown
+  >;
+  const env: Record<string, string> = {};
 
-  for (const key of [
-    "AUTH_SECRET",
-    "GOOGLE_SERVICE_ACCOUNT_EMAIL",
-    "GOOGLE_PRIVATE_KEY",
-    "GOOGLE_SHEET_ID",
-    "RESEND_API_KEY",
-    "EMAIL_FROM",
-  ] as const) {
-    if (!env[key]) {
+  for (const key of REQUIRED_KEYS) {
+    const value = raw[key];
+    if (value === undefined || value === null || value === "") {
       throw new MissingConfigError(key);
     }
+    if (typeof value !== "string") {
+      throw new InvalidConfigError(key, "expected a string");
+    }
+    // Trimmed because pasting into a dashboard field commonly picks up a
+    // trailing newline, which would silently change the signing key.
+    const trimmed = value.trim();
+    if (!trimmed) {
+      throw new InvalidConfigError(key, "value is blank");
+    }
+    env[key] = trimmed;
   }
 
-  return env;
+  // A short secret still produces valid HMACs — just guessable ones, which
+  // would make session cookies and magic links forgeable. Fail loudly
+  // rather than accept a weak key.
+  if (env.AUTH_SECRET.length < MIN_AUTH_SECRET_LENGTH) {
+    throw new InvalidConfigError(
+      "AUTH_SECRET",
+      `must be at least ${MIN_AUTH_SECRET_LENGTH} characters; generate one with \`openssl rand -base64 32\``,
+    );
+  }
+
+  return env as unknown as AuthEnv;
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -14,7 +14,7 @@ export interface AuthEnv {
   GOOGLE_PRIVATE_KEY: string;
   /** Spreadsheet ID of the resident directory. */
   GOOGLE_SHEET_ID: string;
-  /** Optional A1 range containing the directory table. Defaults to `A1:H`. */
+  /** Optional A1 range holding the addresses. Defaults to `emails!A:A`. */
   GOOGLE_SHEET_RANGE?: string;
   /** Resend API key used to deliver magic-link emails. */
   RESEND_API_KEY: string;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,44 @@
+/**
+ * Runtime environment access for auth features.
+ *
+ * Secrets are provided via Cloudflare Worker secrets in production
+ * (`wrangler secret put ...`) and `.dev.vars` during local development
+ * (loaded through the Cloudflare platform proxy).
+ */
+export interface AuthEnv {
+  /** Secret used to sign magic-link tokens and session cookies. */
+  AUTH_SECRET: string;
+  /** Service account with read access to the directory sheet. */
+  GOOGLE_SERVICE_ACCOUNT_EMAIL: string;
+  /** Service account private key (PEM, `\n` may be escaped). */
+  GOOGLE_PRIVATE_KEY: string;
+  /** Spreadsheet ID of the resident directory. */
+  GOOGLE_SHEET_ID: string;
+  /** Optional A1 range containing the directory table. Defaults to `A1:H`. */
+  GOOGLE_SHEET_RANGE?: string;
+  /** Resend API key used to deliver magic-link emails. */
+  RESEND_API_KEY: string;
+  /** From address, e.g. `Falls Creek Ranch <no-reply@fallscreekranch.org>`. */
+  EMAIL_FROM: string;
+}
+
+export function getAuthEnv(locals: App.Locals): AuthEnv {
+  const runtime = (locals as { runtime?: { env?: Record<string, unknown> } })
+    .runtime;
+  const env = { ...import.meta.env, ...runtime?.env } as AuthEnv;
+
+  for (const key of [
+    "AUTH_SECRET",
+    "GOOGLE_SERVICE_ACCOUNT_EMAIL",
+    "GOOGLE_PRIVATE_KEY",
+    "GOOGLE_SHEET_ID",
+    "RESEND_API_KEY",
+    "EMAIL_FROM",
+  ] as const) {
+    if (!env[key]) {
+      throw new Error(`Missing required environment variable: ${key}`);
+    }
+  }
+
+  return env;
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -56,6 +56,12 @@ const REQUIRED_KEYS = [
   "EMAIL_FROM",
 ] as const;
 
+/**
+ * Absent is fine, but a value that *is* set has to survive into the
+ * returned env — otherwise configuring it would silently do nothing.
+ */
+const OPTIONAL_KEYS = ["GOOGLE_SHEET_RANGE"] as const;
+
 export function getAuthEnv(locals: App.Locals): AuthEnv {
   const runtime = (locals as { runtime?: { env?: Record<string, unknown> } })
     .runtime;
@@ -92,6 +98,17 @@ export function getAuthEnv(locals: App.Locals): AuthEnv {
       continue;
     }
     env[key] = trimmed;
+  }
+
+  for (const key of OPTIONAL_KEYS) {
+    const value = raw[key];
+    if (value === undefined || value === null || value === "") continue;
+    if (typeof value !== "string") {
+      fault(key, "is not a string");
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed) env[key] = trimmed;
   }
 
   // A short secret still produces valid HMACs — just guessable ones, which

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,46 @@
+import type { AstroCookies } from "astro";
+import { signToken, verifyToken } from "./tokens";
+
+export const SESSION_COOKIE = "fcr_session";
+
+/** Magic links are valid for 30 minutes. */
+export const MAGIC_LINK_TTL_SECONDS = 30 * 60;
+
+/** Sessions last 30 days. */
+export const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+export async function createSession(
+  cookies: AstroCookies,
+  email: string,
+  secret: string,
+): Promise<void> {
+  const token = await signToken(
+    {
+      email,
+      purpose: "session",
+      exp: Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS,
+    },
+    secret,
+  );
+  cookies.set(SESSION_COOKIE, token, {
+    path: "/",
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    maxAge: SESSION_TTL_SECONDS,
+  });
+}
+
+export async function getSessionEmail(
+  cookies: AstroCookies,
+  secret: string,
+): Promise<string | null> {
+  const token = cookies.get(SESSION_COOKIE)?.value;
+  if (!token) return null;
+  const payload = await verifyToken(token, "session", secret);
+  return payload?.email ?? null;
+}
+
+export function clearSession(cookies: AstroCookies): void {
+  cookies.delete(SESSION_COOKIE, { path: "/" });
+}

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -1,0 +1,91 @@
+/**
+ * Stateless signed tokens (HMAC-SHA256) used for both magic links and
+ * session cookies. Format: `base64url(payload).base64url(signature)`.
+ *
+ * The `purpose` field prevents a magic-link token from being replayed as a
+ * session cookie (and vice versa).
+ */
+
+export type TokenPurpose = "magic-link" | "session";
+
+export interface TokenPayload {
+  email: string;
+  purpose: TokenPurpose;
+  /** Expiry, unix seconds. */
+  exp: number;
+}
+
+const encoder = new TextEncoder();
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlDecode(value: string): Uint8Array {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(base64 + "=".repeat((4 - (base64.length % 4)) % 4));
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0));
+}
+
+async function importKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+export async function signToken(
+  payload: TokenPayload,
+  secret: string,
+): Promise<string> {
+  const key = await importKey(secret);
+  const body = base64UrlEncode(encoder.encode(JSON.stringify(payload)));
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+  return `${body}.${base64UrlEncode(new Uint8Array(signature))}`;
+}
+
+export async function verifyToken(
+  token: string,
+  purpose: TokenPurpose,
+  secret: string,
+): Promise<TokenPayload | null> {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  const [body, signature] = parts;
+
+  let signatureBytes: Uint8Array;
+  try {
+    signatureBytes = base64UrlDecode(signature);
+  } catch {
+    return null;
+  }
+
+  const key = await importKey(secret);
+  const valid = await crypto.subtle.verify(
+    "HMAC",
+    key,
+    signatureBytes as unknown as ArrayBuffer,
+    encoder.encode(body),
+  );
+  if (!valid) return null;
+
+  let payload: TokenPayload;
+  try {
+    payload = JSON.parse(new TextDecoder().decode(base64UrlDecode(body)));
+  } catch {
+    return null;
+  }
+
+  if (payload.purpose !== purpose) return null;
+  if (typeof payload.exp !== "number" || payload.exp * 1000 < Date.now()) {
+    return null;
+  }
+  if (typeof payload.email !== "string" || !payload.email) return null;
+
+  return payload;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,5 @@
 import { defineMiddleware } from "astro:middleware";
-import { getAuthEnv } from "~/lib/env";
+import { getAuthEnv, MissingConfigError } from "~/lib/env";
 import { getSessionEmail } from "~/lib/session";
 
 /**
@@ -8,13 +8,31 @@ import { getSessionEmail } from "~/lib/session";
  */
 export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname } = context.url;
-  if (pathname === "/members" || pathname.startsWith("/members/")) {
-    const env = getAuthEnv(context.locals);
-    const email = await getSessionEmail(context.cookies, env.AUTH_SECRET);
-    if (!email) {
-      return context.redirect("/login/?error=required");
-    }
-    context.locals.user = { email };
+  if (pathname !== "/members" && !pathname.startsWith("/members/")) {
+    return next();
   }
+
+  let email: string | null = null;
+  try {
+    const env = getAuthEnv(context.locals);
+    email = await getSessionEmail(context.cookies, env.AUTH_SECRET);
+  } catch (error) {
+    // Without AUTH_SECRET no session can be verified, so this must fail
+    // closed — but as an explained refusal rather than an unhandled 500,
+    // which is what an unconfigured deployment used to return here.
+    if (error instanceof MissingConfigError) {
+      console.error(
+        `Members area is unavailable: ${error.message}. Set the required secrets on the Cloudflare project.`,
+      );
+      return context.redirect("/login/?error=unavailable");
+    }
+    throw error;
+  }
+
+  if (!email) {
+    return context.redirect("/login/?error=required");
+  }
+
+  context.locals.user = { email };
   return next();
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,7 +7,8 @@ import { getSessionEmail } from "~/lib/session";
  * session cookie (obtained via the magic-link flow at /login).
  */
 export const onRequest = defineMiddleware(async (context, next) => {
-  if (context.url.pathname.startsWith("/members")) {
+  const { pathname } = context.url;
+  if (pathname === "/members" || pathname.startsWith("/members/")) {
     const env = getAuthEnv(context.locals);
     const email = await getSessionEmail(context.cookies, env.AUTH_SECRET);
     if (!email) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,5 @@
 import { defineMiddleware } from "astro:middleware";
-import { getAuthEnv, MissingConfigError } from "~/lib/env";
+import { ConfigError, getAuthEnv } from "~/lib/env";
 import { getSessionEmail } from "~/lib/session";
 
 /**
@@ -20,7 +20,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     // Without AUTH_SECRET no session can be verified, so this must fail
     // closed — but as an explained refusal rather than an unhandled 500,
     // which is what an unconfigured deployment used to return here.
-    if (error instanceof MissingConfigError) {
+    if (error instanceof ConfigError) {
       console.error(
         `Members area is unavailable: ${error.message}. Set the required secrets on the Cloudflare project.`,
       );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,9 +22,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
     // which is what an unconfigured deployment used to return here.
     if (error instanceof ConfigError) {
       console.error(
-        `Members area is unavailable: ${error.message}. Set the required secrets on the Cloudflare project.`,
+        `Members area is unavailable: ${error.message}. Set these on the Cloudflare project.`,
       );
-      return context.redirect("/login/?error=unavailable");
+      // The names ride along so the login page can name them too — /login
+      // is a static asset and can only learn this from the URL.
+      return context.redirect(
+        `/login/?error=unavailable&missing=${encodeURIComponent(error.keys.join(","))}`,
+      );
     }
     throw error;
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,19 @@
+import { defineMiddleware } from "astro:middleware";
+import { getAuthEnv } from "~/lib/env";
+import { getSessionEmail } from "~/lib/session";
+
+/**
+ * Guards the members-only area. Everything under /members requires a valid
+ * session cookie (obtained via the magic-link flow at /login).
+ */
+export const onRequest = defineMiddleware(async (context, next) => {
+  if (context.url.pathname.startsWith("/members")) {
+    const env = getAuthEnv(context.locals);
+    const email = await getSessionEmail(context.cookies, env.AUTH_SECRET);
+    if (!email) {
+      return context.redirect("/login/?error=required");
+    }
+    context.locals.user = { email };
+  }
+  return next();
+});

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -3,7 +3,9 @@ import { clearSession } from "~/lib/session";
 
 export const prerender = false;
 
-export const GET: APIRoute = async ({ cookies, redirect }) => {
+// POST only: a GET endpoint would let any cross-site navigation force a
+// sign-out.
+export const POST: APIRoute = async ({ cookies, redirect }) => {
   clearSession(cookies);
   return redirect("/");
 };

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -1,0 +1,9 @@
+import type { APIRoute } from "astro";
+import { clearSession } from "~/lib/session";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ cookies, redirect }) => {
+  clearSession(cookies);
+  return redirect("/");
+};

--- a/src/pages/api/auth/request.ts
+++ b/src/pages/api/auth/request.ts
@@ -29,14 +29,28 @@ function isThrottled(email: string): boolean {
   return false;
 }
 
-const genericResponse = () =>
-  new Response(
-    JSON.stringify({
-      message:
-        "If that email is in the resident directory, a sign-in link is on its way.",
-    }),
-    { status: 200, headers: { "Content-Type": "application/json" } },
-  );
+/**
+ * A native form post asks for HTML; the enhanced fetch asks for JSON.
+ * Serving both is what lets the form work with JavaScript disabled,
+ * broken, or simply not yet loaded — the failure that is otherwise
+ * invisible, because the browser never sends a request at all.
+ */
+const wantsHtml = (request: Request) =>
+  (request.headers.get("accept") ?? "").includes("text/html");
+
+const seeOther = (location: string) =>
+  new Response(null, { status: 303, headers: { Location: location } });
+
+const genericResponse = (request: Request) =>
+  wantsHtml(request)
+    ? seeOther("/login/?status=sent")
+    : new Response(
+        JSON.stringify({
+          message:
+            "If that email is in the resident directory, a sign-in link is on its way.",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
 
 export const POST: APIRoute = async ({ request, locals, url }) => {
   let email = "";
@@ -55,10 +69,12 @@ export const POST: APIRoute = async ({ request, locals, url }) => {
 
   email = normalizeEmail(email);
   if (!EMAIL_PATTERN.test(email)) {
-    return new Response(
-      JSON.stringify({ message: "Please enter a valid email address." }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
+    return wantsHtml(request)
+      ? seeOther("/login/?error=email")
+      : new Response(
+          JSON.stringify({ message: "Please enter a valid email address." }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
   }
 
   // Checked up front: an unconfigured deployment can never send the link,
@@ -70,18 +86,21 @@ export const POST: APIRoute = async ({ request, locals, url }) => {
   } catch (error) {
     if (error instanceof ConfigError) {
       console.error(`Cannot send sign-in link: ${error.message}`);
-      return new Response(
-        JSON.stringify({
-          message: `Member sign-in isn't available yet — the site is missing configuration (${error.keys.join(", ")}). Please contact board@fallscreekranch.org.`,
-        }),
-        { status: 503, headers: { "Content-Type": "application/json" } },
-      );
+      const missing = encodeURIComponent(error.keys.join(","));
+      return wantsHtml(request)
+        ? seeOther(`/login/?error=unavailable&missing=${missing}`)
+        : new Response(
+            JSON.stringify({
+              message: `Member sign-in isn't available yet — the site is missing configuration (${error.keys.join(", ")}). Please contact board@fallscreekranch.org.`,
+            }),
+            { status: 503, headers: { "Content-Type": "application/json" } },
+          );
     }
     throw error;
   }
 
   if (isThrottled(email)) {
-    return genericResponse();
+    return genericResponse(request);
   }
 
   // The directory lookup and email delivery run off the response path so
@@ -137,5 +156,5 @@ export const POST: APIRoute = async ({ request, locals, url }) => {
     await deliver();
   }
 
-  return genericResponse();
+  return genericResponse(request);
 };

--- a/src/pages/api/auth/request.ts
+++ b/src/pages/api/auth/request.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getAuthEnv, MissingConfigError } from "~/lib/env";
+import { ConfigError, getAuthEnv } from "~/lib/env";
 import { isEmailInDirectory, normalizeEmail } from "~/lib/directory";
 import { sendMagicLinkEmail } from "~/lib/email";
 import { signToken } from "~/lib/tokens";
@@ -68,7 +68,7 @@ export const POST: APIRoute = async ({ request, locals, url }) => {
   try {
     getAuthEnv(locals);
   } catch (error) {
-    if (error instanceof MissingConfigError) {
+    if (error instanceof ConfigError) {
       console.error(`Cannot send sign-in link: ${error.message}`);
       return new Response(
         JSON.stringify({

--- a/src/pages/api/auth/request.ts
+++ b/src/pages/api/auth/request.ts
@@ -88,36 +88,53 @@ export const POST: APIRoute = async ({ request, locals, url }) => {
   // that status, body, and timing are identical whether or not the email is
   // in the directory (and whether or not delivery succeeds) — the form
   // can't be used to probe who is a resident. Failures are logged only.
+  // Every outcome is logged. The response stays deliberately uniform, but
+  // the log is private to the operator, and without it "no email arrived"
+  // is indistinguishable from "that address isn't a resident".
   const deliver = async () => {
     try {
       const env = getAuthEnv(locals);
-      if (await isEmailInDirectory(env, email)) {
-        const token = await signToken(
-          {
-            email,
-            purpose: "magic-link",
-            exp: Math.floor(Date.now() / 1000) + MAGIC_LINK_TTL_SECONDS,
-          },
-          env.AUTH_SECRET,
+      const lookup = await isEmailInDirectory(env, email);
+      if (!lookup.found) {
+        console.log(
+          `No sign-in link for ${email}: not found among ${lookup.scanned} address(es) in ${lookup.range}`,
         );
-        const link = new URL(
-          `/api/auth/verify?token=${encodeURIComponent(token)}`,
-          url.origin,
-        ).toString();
-        await sendMagicLinkEmail(env, email, link);
+        return;
       }
+
+      const token = await signToken(
+        {
+          email,
+          purpose: "magic-link",
+          exp: Math.floor(Date.now() / 1000) + MAGIC_LINK_TTL_SECONDS,
+        },
+        env.AUTH_SECRET,
+      );
+      const link = new URL(
+        `/api/auth/verify?token=${encodeURIComponent(token)}`,
+        url.origin,
+      ).toString();
+      await sendMagicLinkEmail(env, email, link);
+      console.log(`Sign-in link sent to ${email}`);
     } catch (error) {
-      console.error("Magic link delivery failed:", error);
+      console.error(
+        `Sign-in link for ${email} failed:`,
+        error instanceof Error ? error.message : error,
+      );
     }
   };
 
-  const runtime = (
+  const ctx = (
     locals as { runtime?: { ctx?: { waitUntil?: (p: Promise<unknown>) => void } } }
-  ).runtime;
-  if (runtime?.ctx?.waitUntil) {
-    runtime.ctx.waitUntil(deliver());
+  ).runtime?.ctx;
+  if (ctx?.waitUntil) {
+    ctx.waitUntil(deliver());
   } else {
-    void deliver();
+    // Without waitUntil the worker can be torn down the moment the response
+    // is returned, silently dropping the send. Awaiting costs a uniform
+    // delay on every request — a far better trade than losing the email.
+    console.warn("waitUntil unavailable; sending the sign-in link inline");
+    await deliver();
   }
 
   return genericResponse();

--- a/src/pages/api/auth/request.ts
+++ b/src/pages/api/auth/request.ts
@@ -13,6 +13,21 @@ const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 // Sheets and Resend APIs. Not a real rate limiter (isolates are ephemeral).
 const recentRequests = new Map<string, number>();
 const THROTTLE_MS = 60_000;
+const MAX_TRACKED_EMAILS = 5_000;
+
+function isThrottled(email: string): boolean {
+  const now = Date.now();
+  for (const [key, timestamp] of recentRequests) {
+    if (now - timestamp >= THROTTLE_MS) recentRequests.delete(key);
+  }
+  if (recentRequests.has(email)) return true;
+  if (recentRequests.size >= MAX_TRACKED_EMAILS) {
+    const oldest = recentRequests.keys().next().value;
+    if (oldest !== undefined) recentRequests.delete(oldest);
+  }
+  recentRequests.set(email, now);
+  return false;
+}
 
 const genericResponse = () =>
   new Response(
@@ -46,40 +61,44 @@ export const POST: APIRoute = async ({ request, locals, url }) => {
     );
   }
 
-  const lastRequest = recentRequests.get(email);
-  if (lastRequest && Date.now() - lastRequest < THROTTLE_MS) {
+  if (isThrottled(email)) {
     return genericResponse();
   }
-  recentRequests.set(email, Date.now());
 
-  try {
-    const env = getAuthEnv(locals);
-
-    // Always return the same response whether or not the email matched, so
-    // the form can't be used to probe who is in the directory.
-    if (await isEmailInDirectory(env, email)) {
-      const token = await signToken(
-        {
-          email,
-          purpose: "magic-link",
-          exp: Math.floor(Date.now() / 1000) + MAGIC_LINK_TTL_SECONDS,
-        },
-        env.AUTH_SECRET,
-      );
-      const link = new URL(
-        `/api/auth/verify?token=${encodeURIComponent(token)}`,
-        url.origin,
-      ).toString();
-      await sendMagicLinkEmail(env, email, link);
+  // The directory lookup and email delivery run off the response path so
+  // that status, body, and timing are identical whether or not the email is
+  // in the directory (and whether or not delivery succeeds) — the form
+  // can't be used to probe who is a resident. Failures are logged only.
+  const deliver = async () => {
+    try {
+      const env = getAuthEnv(locals);
+      if (await isEmailInDirectory(env, email)) {
+        const token = await signToken(
+          {
+            email,
+            purpose: "magic-link",
+            exp: Math.floor(Date.now() / 1000) + MAGIC_LINK_TTL_SECONDS,
+          },
+          env.AUTH_SECRET,
+        );
+        const link = new URL(
+          `/api/auth/verify?token=${encodeURIComponent(token)}`,
+          url.origin,
+        ).toString();
+        await sendMagicLinkEmail(env, email, link);
+      }
+    } catch (error) {
+      console.error("Magic link delivery failed:", error);
     }
-  } catch (error) {
-    console.error("Magic link request failed:", error);
-    return new Response(
-      JSON.stringify({
-        message: "Something went wrong on our end. Please try again later.",
-      }),
-      { status: 500, headers: { "Content-Type": "application/json" } },
-    );
+  };
+
+  const runtime = (
+    locals as { runtime?: { ctx?: { waitUntil?: (p: Promise<unknown>) => void } } }
+  ).runtime;
+  if (runtime?.ctx?.waitUntil) {
+    runtime.ctx.waitUntil(deliver());
+  } else {
+    void deliver();
   }
 
   return genericResponse();

--- a/src/pages/api/auth/request.ts
+++ b/src/pages/api/auth/request.ts
@@ -72,8 +72,7 @@ export const POST: APIRoute = async ({ request, locals, url }) => {
       console.error(`Cannot send sign-in link: ${error.message}`);
       return new Response(
         JSON.stringify({
-          message:
-            "Member sign-in isn't available yet. Please contact board@fallscreekranch.org.",
+          message: `Member sign-in isn't available yet — the site is missing configuration (${error.keys.join(", ")}). Please contact board@fallscreekranch.org.`,
         }),
         { status: 503, headers: { "Content-Type": "application/json" } },
       );

--- a/src/pages/api/auth/request.ts
+++ b/src/pages/api/auth/request.ts
@@ -1,0 +1,86 @@
+import type { APIRoute } from "astro";
+import { getAuthEnv } from "~/lib/env";
+import { isEmailInDirectory, normalizeEmail } from "~/lib/directory";
+import { sendMagicLinkEmail } from "~/lib/email";
+import { signToken } from "~/lib/tokens";
+import { MAGIC_LINK_TTL_SECONDS } from "~/lib/session";
+
+export const prerender = false;
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Best-effort per-isolate throttle so a stuck client can't hammer the
+// Sheets and Resend APIs. Not a real rate limiter (isolates are ephemeral).
+const recentRequests = new Map<string, number>();
+const THROTTLE_MS = 60_000;
+
+const genericResponse = () =>
+  new Response(
+    JSON.stringify({
+      message:
+        "If that email is in the resident directory, a sign-in link is on its way.",
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+
+export const POST: APIRoute = async ({ request, locals, url }) => {
+  let email = "";
+  try {
+    const contentType = request.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      const body = (await request.json()) as { email?: string };
+      email = body.email ?? "";
+    } else {
+      const form = await request.formData();
+      email = String(form.get("email") ?? "");
+    }
+  } catch {
+    // fall through to validation below
+  }
+
+  email = normalizeEmail(email);
+  if (!EMAIL_PATTERN.test(email)) {
+    return new Response(
+      JSON.stringify({ message: "Please enter a valid email address." }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const lastRequest = recentRequests.get(email);
+  if (lastRequest && Date.now() - lastRequest < THROTTLE_MS) {
+    return genericResponse();
+  }
+  recentRequests.set(email, Date.now());
+
+  try {
+    const env = getAuthEnv(locals);
+
+    // Always return the same response whether or not the email matched, so
+    // the form can't be used to probe who is in the directory.
+    if (await isEmailInDirectory(env, email)) {
+      const token = await signToken(
+        {
+          email,
+          purpose: "magic-link",
+          exp: Math.floor(Date.now() / 1000) + MAGIC_LINK_TTL_SECONDS,
+        },
+        env.AUTH_SECRET,
+      );
+      const link = new URL(
+        `/api/auth/verify?token=${encodeURIComponent(token)}`,
+        url.origin,
+      ).toString();
+      await sendMagicLinkEmail(env, email, link);
+    }
+  } catch (error) {
+    console.error("Magic link request failed:", error);
+    return new Response(
+      JSON.stringify({
+        message: "Something went wrong on our end. Please try again later.",
+      }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  return genericResponse();
+};

--- a/src/pages/api/auth/request.ts
+++ b/src/pages/api/auth/request.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getAuthEnv } from "~/lib/env";
+import { getAuthEnv, MissingConfigError } from "~/lib/env";
 import { isEmailInDirectory, normalizeEmail } from "~/lib/directory";
 import { sendMagicLinkEmail } from "~/lib/email";
 import { signToken } from "~/lib/tokens";
@@ -59,6 +59,26 @@ export const POST: APIRoute = async ({ request, locals, url }) => {
       JSON.stringify({ message: "Please enter a valid email address." }),
       { status: 400, headers: { "Content-Type": "application/json" } },
     );
+  }
+
+  // Checked up front: an unconfigured deployment can never send the link,
+  // and "check your inbox" for an email that will never arrive is worse
+  // than saying so. This reveals nothing about the directory — it is a
+  // property of the deployment, identical for every address.
+  try {
+    getAuthEnv(locals);
+  } catch (error) {
+    if (error instanceof MissingConfigError) {
+      console.error(`Cannot send sign-in link: ${error.message}`);
+      return new Response(
+        JSON.stringify({
+          message:
+            "Member sign-in isn't available yet. Please contact board@fallscreekranch.org.",
+        }),
+        { status: 503, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    throw error;
   }
 
   if (isThrottled(email)) {

--- a/src/pages/api/auth/verify.ts
+++ b/src/pages/api/auth/verify.ts
@@ -17,7 +17,9 @@ export const GET: APIRoute = async ({ url, locals, cookies, redirect }) => {
   } catch (error) {
     if (error instanceof ConfigError) {
       console.error(`Cannot verify sign-in link: ${error.message}`);
-      return redirect("/login/?error=unavailable");
+      return redirect(
+        `/login/?error=unavailable&missing=${encodeURIComponent(error.keys.join(","))}`,
+      );
     }
     throw error;
   }

--- a/src/pages/api/auth/verify.ts
+++ b/src/pages/api/auth/verify.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getAuthEnv, MissingConfigError } from "~/lib/env";
+import { ConfigError, getAuthEnv } from "~/lib/env";
 import { verifyToken } from "~/lib/tokens";
 import { createSession } from "~/lib/session";
 
@@ -15,7 +15,7 @@ export const GET: APIRoute = async ({ url, locals, cookies, redirect }) => {
   try {
     env = getAuthEnv(locals);
   } catch (error) {
-    if (error instanceof MissingConfigError) {
+    if (error instanceof ConfigError) {
       console.error(`Cannot verify sign-in link: ${error.message}`);
       return redirect("/login/?error=unavailable");
     }

--- a/src/pages/api/auth/verify.ts
+++ b/src/pages/api/auth/verify.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getAuthEnv } from "~/lib/env";
+import { getAuthEnv, MissingConfigError } from "~/lib/env";
 import { verifyToken } from "~/lib/tokens";
 import { createSession } from "~/lib/session";
 
@@ -11,7 +11,17 @@ export const GET: APIRoute = async ({ url, locals, cookies, redirect }) => {
     return redirect("/login/?error=invalid");
   }
 
-  const env = getAuthEnv(locals);
+  let env;
+  try {
+    env = getAuthEnv(locals);
+  } catch (error) {
+    if (error instanceof MissingConfigError) {
+      console.error(`Cannot verify sign-in link: ${error.message}`);
+      return redirect("/login/?error=unavailable");
+    }
+    throw error;
+  }
+
   const payload = await verifyToken(token, "magic-link", env.AUTH_SECRET);
   if (!payload) {
     return redirect("/login/?error=invalid");

--- a/src/pages/api/auth/verify.ts
+++ b/src/pages/api/auth/verify.ts
@@ -18,5 +18,7 @@ export const GET: APIRoute = async ({ url, locals, cookies, redirect }) => {
   }
 
   await createSession(cookies, payload.email, env.AUTH_SECRET);
-  return redirect("/members/");
+  // No trailing slash: the generated _routes.json routes exactly "/members"
+  // through the worker, so "/members/" would miss it on Cloudflare Pages.
+  return redirect("/members");
 };

--- a/src/pages/api/auth/verify.ts
+++ b/src/pages/api/auth/verify.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from "astro";
+import { getAuthEnv } from "~/lib/env";
+import { verifyToken } from "~/lib/tokens";
+import { createSession } from "~/lib/session";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ url, locals, cookies, redirect }) => {
+  const token = url.searchParams.get("token");
+  if (!token) {
+    return redirect("/login/?error=invalid");
+  }
+
+  const env = getAuthEnv(locals);
+  const payload = await verifyToken(token, "magic-link", env.AUTH_SECRET);
+  if (!payload) {
+    return redirect("/login/?error=invalid");
+  }
+
+  await createSession(cookies, payload.email, env.AUTH_SECRET);
+  return redirect("/members/");
+};

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -19,7 +19,12 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 
   <div id="login-error" class="login-alert" role="alert" hidden></div>
 
-  <form id="login-form" class="login-form">
+  <form
+    id="login-form"
+    class="login-form"
+    method="post"
+    action="/api/auth/request"
+  >
     <label for="email">Email address</label>
     <input
       type="email"
@@ -112,12 +117,20 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 
   const params = new URLSearchParams(window.location.search);
   const error = params.get("error");
+  // A no-JS submission round-trips back here; show the same confirmation.
+  if (params.get("status") === "sent") {
+    form.hidden = true;
+    successBox.hidden = false;
+  }
   if (error === "invalid") {
     errorBox.textContent =
       "That sign-in link is invalid or has expired. Please request a new one.";
     errorBox.hidden = false;
   } else if (error === "required") {
     errorBox.textContent = "Please sign in to view the members area.";
+    errorBox.hidden = false;
+  } else if (error === "email") {
+    errorBox.textContent = "Please enter a valid email address.";
     errorBox.hidden = false;
   } else if (error === "unavailable") {
     // The query string is attacker-controllable, so only well-formed
@@ -142,7 +155,12 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
     try {
       const response = await fetch("/api/auth/request", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        // Accept pins the JSON branch; without JS the same endpoint
+        // answers a native form post with a redirect instead.
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
         body: JSON.stringify({ email: emailInput.value }),
       });
 

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -120,8 +120,16 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
     errorBox.textContent = "Please sign in to view the members area.";
     errorBox.hidden = false;
   } else if (error === "unavailable") {
-    errorBox.textContent =
-      "Member sign-in isn't available yet. Please contact board@fallscreekranch.org.";
+    // The query string is attacker-controllable, so only well-formed
+    // variable names are echoed back, and always as text — enough to name
+    // the real fault without letting anyone put words in the page.
+    const named = (params.get("missing") ?? "")
+      .split(",")
+      .filter((name) => /^[A-Z][A-Z0-9_]{2,63}$/.test(name))
+      .slice(0, 12);
+    errorBox.textContent = named.length
+      ? `Member sign-in isn't set up yet — the site is missing configuration (${named.join(", ")}). Please contact board@fallscreekranch.org.`
+      : "Member sign-in isn't available yet. Please contact board@fallscreekranch.org.";
     errorBox.hidden = false;
   }
 

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -17,7 +17,7 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
     you a sign-in link. No password needed.
   </p>
 
-  <div id="login-error" class="login-alert" hidden></div>
+  <div id="login-error" class="login-alert" role="alert" hidden></div>
 
   <form id="login-form" class="login-form">
     <label for="email">Email address</label>
@@ -32,7 +32,12 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
     <button type="submit" id="login-submit">Email me a sign-in link</button>
   </form>
 
-  <div id="login-success" class="login-alert login-alert--success" hidden>
+  <div
+    id="login-success"
+    class="login-alert login-alert--success"
+    role="status"
+    hidden
+  >
     Check your inbox! If that email is in the resident directory, a sign-in
     link is on its way. The link expires in 30 minutes.
   </div>

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -1,0 +1,149 @@
+---
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+---
+
+<StarlightPage
+  frontmatter={{
+    title: "Member Sign In",
+    slug: "login",
+    description:
+      "Sign in to the Falls Creek Ranch members area with an email link.",
+    tableOfContents: false,
+    pagefind: false,
+  }}
+>
+  <p>
+    Enter the email address on file in the resident directory and we will send
+    you a sign-in link. No password needed.
+  </p>
+
+  <div id="login-error" class="login-alert" hidden></div>
+
+  <form id="login-form" class="login-form">
+    <label for="email">Email address</label>
+    <input
+      type="email"
+      id="email"
+      name="email"
+      required
+      autocomplete="email"
+      placeholder="you@example.com"
+    />
+    <button type="submit" id="login-submit">Email me a sign-in link</button>
+  </form>
+
+  <div id="login-success" class="login-alert login-alert--success" hidden>
+    Check your inbox! If that email is in the resident directory, a sign-in
+    link is on its way. The link expires in 30 minutes.
+  </div>
+
+  <p class="login-help">
+    Not receiving a link? Your email may not match the one in the resident
+    directory — contact
+    <a href="mailto:board@fallscreekranch.org">board@fallscreekranch.org</a>
+    to update it.
+  </p>
+</StarlightPage>
+
+<style>
+  .login-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: 24rem;
+    margin-top: 1rem;
+  }
+  .login-form label {
+    font-weight: 600;
+  }
+  .login-form input {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--sl-color-gray-4);
+    border-radius: 0.5rem;
+    background: var(--sl-color-bg);
+    color: var(--sl-color-white);
+    font-size: var(--sl-text-base);
+  }
+  .login-form button {
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 0.5rem;
+    background: var(--sl-color-accent);
+    color: var(--sl-color-black);
+    font-size: var(--sl-text-base);
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .login-form button:disabled {
+    opacity: 0.6;
+    cursor: wait;
+  }
+  .login-alert {
+    margin-top: 1rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    background: var(--sl-color-red-low);
+    color: var(--sl-color-red-high);
+  }
+  .login-alert--success {
+    background: var(--sl-color-green-low);
+    color: var(--sl-color-green-high);
+  }
+  .login-help {
+    margin-top: 1.5rem;
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-gray-3);
+  }
+</style>
+
+<script>
+  const form = document.getElementById("login-form") as HTMLFormElement;
+  const emailInput = document.getElementById("email") as HTMLInputElement;
+  const submitButton = document.getElementById(
+    "login-submit",
+  ) as HTMLButtonElement;
+  const errorBox = document.getElementById("login-error") as HTMLElement;
+  const successBox = document.getElementById("login-success") as HTMLElement;
+
+  const params = new URLSearchParams(window.location.search);
+  const error = params.get("error");
+  if (error === "invalid") {
+    errorBox.textContent =
+      "That sign-in link is invalid or has expired. Please request a new one.";
+    errorBox.hidden = false;
+  } else if (error === "required") {
+    errorBox.textContent = "Please sign in to view the members area.";
+    errorBox.hidden = false;
+  }
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    errorBox.hidden = true;
+    successBox.hidden = true;
+    submitButton.disabled = true;
+
+    try {
+      const response = await fetch("/api/auth/request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: emailInput.value }),
+      });
+
+      if (response.ok) {
+        form.hidden = true;
+        successBox.hidden = false;
+      } else {
+        const data = await response.json().catch(() => null);
+        errorBox.textContent =
+          data?.message ?? "Something went wrong. Please try again.";
+        errorBox.hidden = false;
+      }
+    } catch {
+      errorBox.textContent =
+        "Could not reach the server. Please check your connection and try again.";
+      errorBox.hidden = false;
+    } finally {
+      submitButton.disabled = false;
+    }
+  });
+</script>

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -119,6 +119,10 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
   } else if (error === "required") {
     errorBox.textContent = "Please sign in to view the members area.";
     errorBox.hidden = false;
+  } else if (error === "unavailable") {
+    errorBox.textContent =
+      "Member sign-in isn't available yet. Please contact board@fallscreekranch.org.";
+    errorBox.hidden = false;
   }
 
   form.addEventListener("submit", async (event) => {

--- a/src/pages/members/index.astro
+++ b/src/pages/members/index.astro
@@ -1,0 +1,33 @@
+---
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+
+export const prerender = false;
+
+// Set by src/middleware.ts — unauthenticated requests are redirected to
+// /login before this page renders.
+const email = Astro.locals.user?.email;
+---
+
+<StarlightPage
+  frontmatter={{
+    title: "Members Area",
+    slug: "members",
+    description: "Members-only resources for Falls Creek Ranch residents.",
+    tableOfContents: false,
+    pagefind: false,
+  }}
+>
+  <p>
+    You are signed in as <strong>{email}</strong>.
+  </p>
+
+  <p>
+    Members-only content will appear here. If there is something you would
+    like to see in this area, let the board know at
+    <a href="mailto:board@fallscreekranch.org">board@fallscreekranch.org</a>.
+  </p>
+
+  <p>
+    <a href="/api/auth/logout">Sign out</a>
+  </p>
+</StarlightPage>

--- a/src/pages/members/index.astro
+++ b/src/pages/members/index.astro
@@ -27,7 +27,19 @@ const email = Astro.locals.user?.email;
     <a href="mailto:board@fallscreekranch.org">board@fallscreekranch.org</a>.
   </p>
 
-  <p>
-    <a href="/api/auth/logout">Sign out</a>
-  </p>
+  <form method="post" action="/api/auth/logout">
+    <button type="submit" class="logout-button">Sign out</button>
+  </form>
 </StarlightPage>
+
+<style>
+  .logout-button {
+    padding: 0.4rem 1rem;
+    border: 1px solid var(--sl-color-gray-4);
+    border-radius: 0.5rem;
+    background: var(--sl-color-bg);
+    color: var(--sl-color-white);
+    font-size: var(--sl-text-sm);
+    cursor: pointer;
+  }
+</style>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,8 @@
+declare namespace App {
+  interface Locals {
+    /** Set by src/middleware.ts for authenticated /members requests. */
+    user?: {
+      email: string;
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Adds a passwordless members sign-in flow: residents enter their email at `/login`, the worker checks it against the **resident directory Google Sheet**, and matching emails receive a signed magic link. Clicking the link sets a session cookie that gates a new `/members/` area.

## How it works

1. **`/login`** (static page, styled with Starlight's `StarlightPage` shell) posts the email to `POST /api/auth/request`
2. The worker looks up the email in the directory sheet's `Email` column via the **Sheets REST API** with the same service account used by the directory automation. The `googleapis` package can't run in a Cloudflare Worker, so `src/lib/directory.ts` implements the service-account JWT flow directly with WebCrypto.
3. If the email matches, a magic link is sent via **Resend** (HMAC-signed token, 30 minute expiry). The directory lookup and delivery run off the response path (`ctx.waitUntil`), so response status, body, and timing are identical whether or not the email matched — the form can't be used to probe who is in the directory. A best-effort per-isolate throttle (60s per email, bounded map) limits abuse of the Sheets/Resend APIs, and all external calls carry 10s timeouts.
4. **`GET /api/auth/verify?token=...`** validates the token and sets a signed, HttpOnly `fcr_session` cookie (30 days), then redirects to `/members`
5. **`src/middleware.ts`** gates `/members` (exact path or subpaths) behind that cookie; `POST /api/auth/logout` clears it (POST-only so cross-site navigation can't force a sign-out; Astro's origin check also rejects cross-origin POSTs)

Tokens are stateless (HMAC-SHA256 signed with `AUTH_SECRET`) — no KV or database needed. A `purpose` field prevents a magic-link token from being replayed as a session cookie. Trade-off: magic links are reusable until they expire (30 min); if strict one-time use is ever needed, a KV-backed nonce can be added.

## Cloudflare Pages compatibility

The adapter output works on Pages unchanged: the build emits `dist/_worker.js` (advanced-mode worker) plus `dist/_routes.json`, which routes only `/api/*` and `/members` through the worker and serves everything else as static assets. No code differences between Pages and Workers deployments.

## Setup required before this works in production

On the Pages project (dashboard → Settings → Environment variables, for **Production and Preview**, or `wrangler pages secret put <NAME> --project-name fcr-website`) — documented in `.dev.vars.example` and `AGENTS.md`:

- `AUTH_SECRET` — random string (`openssl rand -base64 32`)
- `GOOGLE_SERVICE_ACCOUNT_EMAIL` / `GOOGLE_PRIVATE_KEY` — same service account as the directory automation (needs read access to the sheet)
- `GOOGLE_SHEET_ID` — the resident directory spreadsheet
- `GOOGLE_SHEET_RANGE` — optional, defaults to `A1:H`
- `RESEND_API_KEY` / `EMAIL_FROM` — requires verifying `fallscreekranch.org` in [Resend](https://resend.com) (free tier covers this traffic easily). Happy to swap for a different email provider if you prefer.

The Pages project also needs the **`nodejs_compat` compatibility flag** in its settings (Pages does not read `wrangler.jsonc`).

## Testing

- `pnpm build` passes (including `starlight-links-validator`)
- Smoke-tested end to end with `wrangler dev`:
  - `/members` without a session → 302 to `/login/?error=required`; `/membership` unaffected
  - valid magic-link token → session cookie set, `/members` shows the signed-in email
  - expired token and garbage tokens → 302 to `/login/?error=invalid`
  - magic-link token replayed as a session cookie → rejected
  - logout: same-origin POST works, cross-origin POST → 403, GET → 404
- Sheets lookup and Resend delivery need real credentials, so those were verified against API docs but not live

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added passwordless member sign-in using email magic links.
  - Verifies email addresses against the resident directory before sending access links.
  - Added a protected Members area with signed-in email and board contact information.
  - Added secure sessions with expiration and sign-out support.
- **Bug Fixes**
  - Added handling for invalid requests, unavailable services, expired links, and unauthorized access.
- **Documentation**
  - Added setup guidance for authentication, email delivery, directory access, and deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->