### PR TITLE
feat: let members manage their gate license plates via UniFi Access

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -28,3 +28,12 @@ GOOGLE_SHEET_ID=""
 # The fallscreekranch.org domain must be verified in Resend.
 RESEND_API_KEY=""
 EMAIL_FROM="Falls Creek Ranch <no-reply@fallscreekranch.org>"
+
+# UniFi Access (vehicle license plate registration). Optional — the
+# /members/vehicles page shows a "not available yet" notice until both are
+# set. Must be a publicly reachable HTTPS endpoint with a valid certificate
+# fronting the console's Open API port 12445 (e.g. a Cloudflare Tunnel);
+# Workers cannot skip TLS verification for the console's self-signed cert.
+# Token: Access > Settings > Security > Advanced > API Token.
+UNIFI_ACCESS_API_URL=""
+UNIFI_ACCESS_API_TOKEN=""

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -29,13 +29,15 @@ GOOGLE_SHEET_ID=""
 RESEND_API_KEY=""
 EMAIL_FROM="Falls Creek Ranch <no-reply@fallscreekranch.org>"
 
-# UniFi Access (vehicle license plate registration). Optional — the
-# /members/vehicles page shows a "not available yet" notice until both are
-# set. Must be a publicly reachable HTTPS endpoint with a valid certificate
-# fronting the console's Open API port 12445 (e.g. a Cloudflare Tunnel);
-# Workers cannot skip TLS verification for the console's self-signed cert.
-# Token: Access > Settings > General > Advanced > API Token (needs the
-# view:user and edit:user permission scopes). License plate endpoints
-# require UniFi Access 3.3.10 or later.
-UNIFI_ACCESS_API_URL=""
+# UniFi Access (vehicle license plate registration). Only the token is
+# required — until it is set, /members/vehicles shows a "not available
+# yet" notice. Token: Access > Settings > General > Advanced > API Token,
+# with the view:user and edit:user scopes. License plate endpoints need
+# UniFi Access 3.3.10 or later.
 UNIFI_ACCESS_API_TOKEN=""
+
+# Optional: defaults to https://gate.fallscreekranch.org. Set only if the
+# tunnel hostname changes. Must be publicly reachable HTTPS with a valid
+# certificate, fronting the console's Open API port 12445 — Workers cannot
+# skip TLS verification for the console's own self-signed cert.
+# UNIFI_ACCESS_API_URL="https://gate.fallscreekranch.org"

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -34,6 +34,8 @@ EMAIL_FROM="Falls Creek Ranch <no-reply@fallscreekranch.org>"
 # set. Must be a publicly reachable HTTPS endpoint with a valid certificate
 # fronting the console's Open API port 12445 (e.g. a Cloudflare Tunnel);
 # Workers cannot skip TLS verification for the console's self-signed cert.
-# Token: Access > Settings > Security > Advanced > API Token.
+# Token: Access > Settings > General > Advanced > API Token (needs the
+# view:user and edit:user permission scopes). License plate endpoints
+# require UniFi Access 3.3.10 or later.
 UNIFI_ACCESS_API_URL=""
 UNIFI_ACCESS_API_TOKEN=""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,8 +183,17 @@ account at `/members/vehicles` (used for License Plate Unlock at the gate).
 
 - `src/lib/unifi.ts` — minimal Access Open API client (Bearer token,
   `/api/v1/developer` endpoints, `{code, msg, data}` envelope). Members are
-  matched to Access users by session email; plates are read from the user
-  resource and replaced via the license-plates assignment endpoint.
+  matched to Access users by session email (paging `GET /users`). Per the
+  Access API Reference:
+  - **Read** (§3.4) `GET /users/:id` → `license_plates[]` of credential
+    objects: `{id, credential, credential_type: "license",
+    credential_status}`. The plate number is `credential`; `id` is the
+    credential UUID needed to unassign it.
+  - **Assign** (§3.28) `PUT /users/:id/license_plates` — body is a **bare
+    JSON array of plate strings**, not a wrapped object, and PUT *replaces*
+    the collection, so send the full desired set.
+  - **Unassign** (§3.29) `DELETE /users/:id/license_plates/:plate_id`.
+  - License plate endpoints need **UniFi Access 3.3.10 or later**.
 - `src/pages/members/vehicles.astro` — SSR page listing plates with
   add/remove forms; `src/pages/api/members/vehicles.ts` handles the POSTs.
   `/api/members/*` routes are session-gated by `src/middleware.ts` (401).
@@ -193,8 +202,10 @@ account at `/members/vehicles` (used for License Plate Unlock at the gate).
   must be publicly reachable HTTPS with a valid cert fronting the console's
   port 12445 (e.g. Cloudflare Tunnel) — the Worker runs with
   `global_fetch_strictly_public` and cannot skip TLS verification.
-- Members may register up to `MAX_PLATES_PER_USER` (4) plates; plates are
-  normalized to uppercase alphanumeric/dash, 2-10 chars.
+- Members may register up to `MAX_PLATES_PER_USER` (4) plates — our own
+  cap, the API documents no limit. Plates are normalized to uppercase
+  alphanumeric/dash, 2-10 chars. Removals verify the credential ID belongs
+  to the requesting member before calling the delete endpoint.
 
 ## Static Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,27 @@ account at `/members/vehicles` (used for License Plate Unlock at the gate).
   alphanumeric/dash, 2-10 chars. Removals verify the credential ID belongs
   to the requesting member before calling the delete endpoint.
 
+### Error handling
+
+Failures are classified rather than collapsed into one message, because
+the right advice differs — some are the member's to act on, some the
+board's, and some resolve on their own:
+
+- `UnifiApiError` carries the envelope `code` and HTTP `status`.
+  `isConfigurationFault` (401/403, `CODE_AUTH_FAILED`,
+  `CODE_ACCESS_TOKEN_INVALID`, `CODE_UNAUTHORIZED`) means a bad or expired
+  API token — an admin problem, so the UI says to contact the board rather
+  than "try again later". `isRejection` (`CODE_PARAMS_INVALID`,
+  `CODE_OPERATION_FORBIDDEN`) means Access refused the plate, most likely
+  because it is already registered to another resident.
+- 429 and 5xx retry once after 500ms; every other 4xx fails immediately.
+- The API reference documents **no license-plate-specific error codes**
+  (the `CODE_CREDS_*` family is NFC only), so "already taken" can only be
+  inferred from the generic rejection codes. If a real console turns out
+  to return something more specific, add it to `isRejection`.
+- Every failure is logged with the member's email and the attempted
+  action so a support report can be traced in Workers observability.
+
 ## Static Files
 
 PDFs and documents go in `public/uploads/`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,29 @@ account at `/members/vehicles` (used for License Plate Unlock at the gate).
   alphanumeric/dash, 2-10 chars. Removals verify the credential ID belongs
   to the requesting member before calling the delete endpoint.
 
+### Schema validation (Zod)
+
+`zod` is pinned to 3.25.76 to match the copy Astro already bundles for
+content collections, so there is only ever one Zod in the tree.
+
+- **Responses** (`src/lib/unifi.ts`) are parsed, not cast. The console is a
+  trust boundary we cannot exercise from CI — a different Access version,
+  an error payload, or an HTML page from the tunnel would otherwise pass a
+  type assertion and fail confusingly later. A mismatch raises
+  `UnifiSchemaError` naming the offending field, e.g.
+  `license_plates.0.credential: Required`. That is the log line to look
+  for if these shapes ever turn out to be wrong.
+- Schemas are **non-strict**: unknown keys are ignored so a newer Access
+  adding fields can't break us, and only the fields this client depends on
+  are required.
+- `UnifiSchemaError` counts as a configuration fault — a member retrying
+  cannot fix a version mismatch, so the UI points them at the board.
+- **Form input** (`src/pages/api/members/vehicles.ts`) uses a discriminated
+  union on `action`, so each branch accepts only its own fields (a
+  `remove` carrying the add branch's `plate` is rejected). The `add`
+  branch transforms through the same shared `normalizePlate`, because the
+  browser is never the authority on what is valid.
+
 ### Error handling
 
 Failures are classified rather than collapsed into one message, because

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,9 +170,31 @@ Notes:
   for a Workers deployment use `wrangler secret put <NAME>`.
 - The build works on both Cloudflare Pages and Workers: the adapter emits
   `dist/_worker.js` plus `dist/_routes.json`, so Pages serves the static
-  site directly and routes only `/api/*` and `/members` through the worker.
-  The Pages project needs the `nodejs_compat` compatibility flag (Pages
-  does not read `wrangler.jsonc`).
+  site directly and routes only `/api/*` and `/members` (plus subpaths)
+  through the worker. `astro.config.mjs` extends the adapter's include list
+  with the bare `/members` pattern, which `/members/*` alone would miss on
+  Pages. The Pages project needs the `nodejs_compat` compatibility flag
+  (Pages does not read `wrangler.jsonc`).
+
+## Vehicle License Plates (UniFi Access)
+
+Signed-in members can manage the license plates tied to their UniFi Access
+account at `/members/vehicles` (used for License Plate Unlock at the gate).
+
+- `src/lib/unifi.ts` — minimal Access Open API client (Bearer token,
+  `/api/v1/developer` endpoints, `{code, msg, data}` envelope). Members are
+  matched to Access users by session email; plates are read from the user
+  resource and replaced via the license-plates assignment endpoint.
+- `src/pages/members/vehicles.astro` — SSR page listing plates with
+  add/remove forms; `src/pages/api/members/vehicles.ts` handles the POSTs.
+  `/api/members/*` routes are session-gated by `src/middleware.ts` (401).
+- Config (optional): `UNIFI_ACCESS_API_URL` + `UNIFI_ACCESS_API_TOKEN`.
+  Until both are set the page shows a "not available yet" notice. The URL
+  must be publicly reachable HTTPS with a valid cert fronting the console's
+  port 12445 (e.g. Cloudflare Tunnel) — the Worker runs with
+  `global_fetch_strictly_public` and cannot skip TLS verification.
+- Members may register up to `MAX_PLATES_PER_USER` (4) plates; plates are
+  normalized to uppercase alphanumeric/dash, 2-10 chars.
 
 ## Static Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,11 +197,13 @@ account at `/members/vehicles` (used for License Plate Unlock at the gate).
 - `src/pages/members/vehicles.astro` — SSR page listing plates with
   add/remove forms; `src/pages/api/members/vehicles.ts` handles the POSTs.
   `/api/members/*` routes are session-gated by `src/middleware.ts` (401).
-- Config (optional): `UNIFI_ACCESS_API_URL` + `UNIFI_ACCESS_API_TOKEN`.
-  Until both are set the page shows a "not available yet" notice. The URL
-  must be publicly reachable HTTPS with a valid cert fronting the console's
-  port 12445 (e.g. Cloudflare Tunnel) — the Worker runs with
-  `global_fetch_strictly_public` and cannot skip TLS verification.
+- Config: only `UNIFI_ACCESS_API_TOKEN` is required; the page shows a
+  "not available yet" notice until it is set. `UNIFI_ACCESS_API_URL`
+  defaults to `https://gate.fallscreekranch.org` and only needs setting if
+  the tunnel hostname changes. It must be publicly reachable HTTPS with a
+  valid cert fronting the console's port 12445 — the Worker runs with
+  `global_fetch_strictly_public` and cannot skip TLS verification, so the
+  console's own self-signed cert on `<ip>:12445` will not work.
 - Members may register up to `MAX_PLATES_PER_USER` (4) plates — our own
   cap, the API documents no limit. Plates are normalized to uppercase
   alphanumeric/dash, 2-10 chars. Removals verify the credential ID belongs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,25 @@ board's, and some resolve on their own:
 - Every failure is logged with the member's email and the attempted
   action so a support report can be traced in Workers observability.
 
+## Forms (members area)
+
+Sign-in and vehicle plates share one set of controls so they can't drift:
+
+- **Styling:** `src/styles/forms.css` (loaded via `customCss` in
+  `astro.config.mjs`) defines global `.form-*` classes — `form-stack`,
+  `form-input`, `form-button`, `form-alert`, `form-hint`, plus
+  `:focus-visible` states. Everything is expressed in Starlight tokens, so
+  light/dark and the site palette come free. Pages keep only their own
+  layout in a scoped `<style>`; don't re-declare input or button styling.
+- **Validation:** `src/lib/plates.ts` holds the *only* definition of a
+  valid plate. It is dependency-free and imports nothing from Node or
+  Astro, so the identical `normalizePlate` runs in the SSR page, the API
+  route, and the browser. Sharing the function — rather than restating the
+  rule as an HTML `pattern` and again server-side — is what keeps the two
+  sides honest. Astro inlines the client copy (~300 bytes).
+- Client-side validation is an enhancement only: without JS the form still
+  submits and the server reports the same problem via `?status=`.
+
 ## Static Files
 
 PDFs and documents go in `public/uploads/`:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -40,7 +40,7 @@ export default defineConfig({
           `,
         },
       ],
-      customCss: ["./src/styles/custom.css"],
+      customCss: ["./src/styles/custom.css", "./src/styles/forms.css"],
       editLink: {
         baseUrl: "https://github.com/jpoehnelt/fcr-website/edit/main/",
       },

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -91,5 +91,14 @@ export default defineConfig({
     }),
   ],
 
-  adapter: cloudflare()
+  adapter: cloudflare({
+    routes: {
+      extend: {
+        // The generated include collapses member pages to "/members/*",
+        // which does not match the bare "/members" path on Cloudflare
+        // Pages — add it explicitly so the worker serves it there.
+        include: [{ pattern: "/members" }],
+      },
+    },
+  })
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "sharp": "^0.34.4",
     "starlight-links-validator": "^0.19.0",
     "starlight-theme-nova": "^0.10.0",
-    "totp-generator": "^2.0.0"
+    "totp-generator": "^2.0.0",
+    "zod": "3.25.76"
   },
   "packageManager": "pnpm@10.15.1",
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       totp-generator:
         specifier: ^2.0.0
         version: 2.0.0
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
     devDependencies:
       wrangler:
         specifier: ^4.112.0

--- a/src/lib/plates.ts
+++ b/src/lib/plates.ts
@@ -1,0 +1,41 @@
+/**
+ * The single definition of what counts as a valid license plate.
+ *
+ * This module is deliberately dependency-free and free of any Node or
+ * Astro imports, so the exact same code runs in three places: the SSR
+ * page, the API route, and the browser. Sharing the *function* — rather
+ * than restating the rule as an HTML `pattern` attribute and again as a
+ * server-side check — is what stops the two sides from drifting apart.
+ */
+
+const PLATE_CHARS = "A-Z0-9-";
+const PLATE_MIN = 2;
+const PLATE_MAX = 10;
+
+const PLATE_RE = new RegExp(`^[${PLATE_CHARS}]{${PLATE_MIN},${PLATE_MAX}}$`);
+
+/** Longest raw string worth accepting, allowing for typed spaces. */
+export const PLATE_INPUT_MAXLENGTH = PLATE_MAX + 4;
+
+export const PLATE_RULE_TEXT = `Letters, numbers, and dashes — ${PLATE_MIN} to ${PLATE_MAX} characters.`;
+
+/**
+ * Normalizes a plate for storage: uppercase, whitespace removed. Returns
+ * null when the result isn't a plausible plate.
+ *
+ * Normalizing before validating is what lets a member type "abc 123" and
+ * get "ABC123" instead of an error.
+ */
+export function normalizePlate(input: string): string | null {
+  const plate = input.toUpperCase().replace(/\s+/g, "");
+  return PLATE_RE.test(plate) ? plate : null;
+}
+
+/**
+ * Browser-side check, expressed in terms of the same normalization the
+ * server applies, so the two can't disagree about what is valid.
+ */
+export function describePlateProblem(input: string): string | null {
+  if (!input.trim()) return "Enter a license plate.";
+  return normalizePlate(input) === null ? PLATE_RULE_TEXT : null;
+}

--- a/src/lib/unifi.ts
+++ b/src/lib/unifi.ts
@@ -17,6 +17,8 @@
  * `noTLSVerify` the console's self-signed certificate).
  */
 
+import { z } from "zod";
+
 export interface UnifiEnv {
   /** e.g. https://access-api.fallscreekranch.org (fronting <console>:12445) */
   UNIFI_ACCESS_API_URL: string;
@@ -35,6 +37,53 @@ export function getUnifiEnv(locals: App.Locals): UnifiEnv | null {
   return env as UnifiEnv;
 }
 
+/**
+ * Response schemas.
+ *
+ * These are validated rather than cast, because the console is a trust
+ * boundary we cannot test against from CI: a different Access version, an
+ * error payload, or an HTML page from the tunnel would otherwise sail
+ * through a type assertion and fail confusingly much later. A schema
+ * failure names the exact field that differed, which is the diagnostic
+ * worth having if any of these shapes turn out to be wrong.
+ *
+ * Objects are non-strict on purpose — unknown keys are ignored, so a
+ * newer Access adding fields won't break us. Only the fields this client
+ * actually depends on are required.
+ */
+const licensePlateSchema = z.object({
+  id: z.string().min(1),
+  credential: z.string().min(1),
+  credential_type: z.string().optional(),
+  credential_status: z.string().optional(),
+});
+
+const userSchema = z.object({
+  id: z.string().min(1),
+  user_email: z.string().optional(),
+  /** Present on the search endpoint; absent on users/:id. */
+  email: z.string().optional(),
+  license_plates: z.array(licensePlateSchema).nullish(),
+});
+
+const userListSchema = z.array(userSchema);
+
+const paginationSchema = z.object({
+  page_num: z.number(),
+  page_size: z.number(),
+  total: z.number(),
+});
+
+/** The `{code, msg, data}` wrapper every endpoint returns. */
+const envelopeSchema = z.object({
+  code: z.string(),
+  msg: z.string().optional(),
+  data: z.unknown().optional(),
+  pagination: paginationSchema.optional(),
+});
+
+type Pagination = z.infer<typeof paginationSchema>;
+
 /** A license plate credential as returned on the user resource. */
 export interface LicensePlate {
   /** Unique ID of the credential — required to unassign it. */
@@ -45,33 +94,19 @@ export interface LicensePlate {
   status: string;
 }
 
-interface RawLicensePlate {
-  id?: string;
-  credential?: string;
-  credential_type?: string;
-  credential_status?: string;
-}
-
-interface RawUser {
-  id: string;
-  first_name?: string;
-  last_name?: string;
-  user_email?: string;
-  /** Present on the search endpoint; absent on users/:id. */
-  email?: string;
-  license_plates?: RawLicensePlate[];
-}
-
 export interface UnifiUser {
   id: string;
   email: string;
 }
 
-interface Envelope<T> {
-  code: string;
-  msg?: string;
-  data?: T;
-  pagination?: { page_num: number; page_size: number; total: number };
+/** Renders Zod issues as `path: message`, for logs and error text. */
+function formatIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.join(".");
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join("; ");
 }
 
 /**
@@ -125,6 +160,23 @@ function isRetryable(status: number): boolean {
 }
 
 /**
+ * The console answered, but not with the shape we expect. Treated as a
+ * configuration fault: a member retrying can't fix a version mismatch or
+ * a tunnel returning the wrong thing, so the UI points at the board while
+ * the log carries the offending field.
+ */
+export class UnifiSchemaError extends UnifiApiError {
+  constructor(context: string, issues: string) {
+    super(`UniFi Access ${context} returned an unexpected shape — ${issues}`);
+    this.name = "UnifiSchemaError";
+  }
+
+  override get isConfigurationFault(): boolean {
+    return true;
+  }
+}
+
+/**
  * Plates a member may register through this site. The API documents no
  * limit — this is our own cap to keep the gate list manageable.
  */
@@ -134,12 +186,18 @@ const PAGE_SIZE = 100;
 /** Safety valve so a paging bug can't loop against the console forever. */
 const MAX_PAGES = 25;
 
+interface Parsed<T> {
+  data: T;
+  pagination?: Pagination;
+}
+
 async function attempt<T>(
   env: UnifiEnv,
   method: string,
   path: string,
+  schema: z.ZodType<T>,
   body?: unknown,
-): Promise<Envelope<T>> {
+): Promise<Parsed<T>> {
   let response: Response;
   try {
     response = await fetch(
@@ -165,11 +223,13 @@ async function attempt<T>(
 
   if (!response.ok) {
     // Error responses still carry the envelope, and its code is more
-    // specific than the HTTP status — keep it when it parses.
-    const code = await response
+    // specific than the HTTP status — keep it when it parses. Parsed
+    // leniently: an error path must never fail on a malformed body.
+    const parsed = await response
       .json()
-      .then((parsed) => (parsed as Envelope<T>)?.code)
-      .catch(() => undefined);
+      .then((body) => envelopeSchema.safeParse(body))
+      .catch(() => null);
+    const code = parsed?.success ? parsed.data.code : undefined;
     throw new UnifiApiError(
       `UniFi Access ${method} ${path} failed: HTTP ${response.status}${code ? ` (${code})` : ""}`,
       code,
@@ -177,15 +237,36 @@ async function attempt<T>(
     );
   }
 
-  const envelope = (await response.json()) as Envelope<T>;
-  if (envelope.code !== "SUCCESS") {
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new UnifiSchemaError(`${method} ${path}`, "response was not JSON");
+  }
+
+  const envelope = envelopeSchema.safeParse(payload);
+  if (!envelope.success) {
+    throw new UnifiSchemaError(
+      `${method} ${path}`,
+      formatIssues(envelope.error),
+    );
+  }
+  if (envelope.data.code !== "SUCCESS") {
     throw new UnifiApiError(
-      `UniFi Access ${method} ${path} returned ${envelope.code}: ${envelope.msg ?? ""}`,
-      envelope.code,
+      `UniFi Access ${method} ${path} returned ${envelope.data.code}: ${envelope.data.msg ?? ""}`,
+      envelope.data.code,
       response.status,
     );
   }
-  return envelope;
+
+  const data = schema.safeParse(envelope.data.data);
+  if (!data.success) {
+    throw new UnifiSchemaError(
+      `${method} ${path} data`,
+      formatIssues(data.error),
+    );
+  }
+  return { data: data.data, pagination: envelope.data.pagination };
 }
 
 /**
@@ -198,10 +279,11 @@ async function request<T>(
   env: UnifiEnv,
   method: string,
   path: string,
+  schema: z.ZodType<T>,
   body?: unknown,
-): Promise<Envelope<T>> {
+): Promise<Parsed<T>> {
   try {
-    return await attempt<T>(env, method, path, body);
+    return await attempt<T>(env, method, path, schema, body);
   } catch (error) {
     const retryable =
       error instanceof UnifiApiError &&
@@ -210,11 +292,11 @@ async function request<T>(
     if (!retryable) throw error;
 
     await new Promise((resolve) => setTimeout(resolve, 500));
-    return attempt<T>(env, method, path, body);
+    return attempt<T>(env, method, path, schema, body);
   }
 }
 
-function emailOf(user: RawUser): string {
+function emailOf(user: z.infer<typeof userSchema>): string {
   return (user.user_email || user.email || "").trim().toLowerCase();
 }
 
@@ -230,12 +312,13 @@ export async function findUserByEmail(
   if (!target) return null;
 
   for (let pageNum = 1; pageNum <= MAX_PAGES; pageNum++) {
-    const { data: users, pagination } = await request<RawUser[]>(
+    const { data: users, pagination } = await request(
       env,
       "GET",
       `/users?page_num=${pageNum}&page_size=${PAGE_SIZE}`,
+      userListSchema,
     );
-    if (!users?.length) return null;
+    if (!users.length) return null;
 
     const match = users.find((user) => emailOf(user) === target);
     if (match) return { id: match.id, email: emailOf(match) };
@@ -250,28 +333,24 @@ export async function findUserByEmail(
   return null;
 }
 
-function toLicensePlate(raw: RawLicensePlate): LicensePlate | null {
-  if (!raw.id || !raw.credential) return null;
-  return {
-    id: raw.id,
-    plate: raw.credential,
-    status: raw.credential_status ?? "active",
-  };
-}
-
 /** Reads the license plates currently assigned to a user (spec 3.4). */
 export async function getLicensePlates(
   env: UnifiEnv,
   userId: string,
 ): Promise<LicensePlate[]> {
-  const { data: user } = await request<RawUser>(
+  const { data: user } = await request(
     env,
     "GET",
     `/users/${encodeURIComponent(userId)}`,
+    userSchema,
   );
-  return (user?.license_plates ?? [])
-    .map(toLicensePlate)
-    .filter((plate): plate is LicensePlate => plate !== null);
+  // The schema has already guaranteed id and credential are present, so
+  // a plate can no longer be silently dropped for being malformed.
+  return (user.license_plates ?? []).map((raw) => ({
+    id: raw.id,
+    plate: raw.credential,
+    status: raw.credential_status ?? "active",
+  }));
 }
 
 /**
@@ -284,10 +363,12 @@ export async function assignLicensePlates(
   userId: string,
   plates: string[],
 ): Promise<void> {
+  // Writes answer with `data: null`; only the envelope matters here.
   await request(
     env,
     "PUT",
     `/users/${encodeURIComponent(userId)}/license_plates`,
+    z.unknown(),
     plates,
   );
 }
@@ -302,6 +383,7 @@ export async function unassignLicensePlate(
     env,
     "DELETE",
     `/users/${encodeURIComponent(userId)}/license_plates/${encodeURIComponent(plateId)}`,
+    z.unknown(),
   );
 }
 

--- a/src/lib/unifi.ts
+++ b/src/lib/unifi.ts
@@ -305,11 +305,6 @@ export async function unassignLicensePlate(
   );
 }
 
-/**
- * Normalizes a plate for storage: uppercase, no whitespace. Returns null
- * if the result isn't a plausible plate (2-10 chars, A-Z / 0-9 / dash).
- */
-export function normalizePlate(input: string): string | null {
-  const plate = input.toUpperCase().replace(/\s+/g, "");
-  return /^[A-Z0-9-]{2,10}$/.test(plate) ? plate : null;
-}
+// Plate validation lives in ~/lib/plates so the browser can run the very
+// same rule; re-exported here for callers already importing this module.
+export { normalizePlate } from "./plates";

--- a/src/lib/unifi.ts
+++ b/src/lib/unifi.ts
@@ -1,0 +1,145 @@
+/**
+ * Minimal UniFi Access developer API client for managing the license
+ * plates assigned to a user (used for License Plate Unlock at the gate).
+ *
+ * Talks to the Access Open API server (default `https://<console>:12445`,
+ * `Authorization: Bearer <token>`, endpoints under `/api/v1/developer`).
+ * Every response uses the `{ code, msg, data }` envelope with
+ * `code === "SUCCESS"` on success.
+ *
+ * Deployment note: the Worker runs with `global_fetch_strictly_public`, and
+ * Workers cannot skip TLS verification, so `UNIFI_ACCESS_API_URL` must be a
+ * publicly resolvable HTTPS endpoint with a valid certificate — in practice
+ * a Cloudflare Tunnel in front of the console's 12445 port (the tunnel can
+ * `noTLSVerify` the self-signed origin).
+ */
+
+export interface UnifiEnv {
+  /** e.g. https://access-api.fallscreekranch.org (fronting <console>:12445) */
+  UNIFI_ACCESS_API_URL: string;
+  /** API token created in Access > Settings > Security > Advanced. */
+  UNIFI_ACCESS_API_TOKEN: string;
+}
+
+/** Returns the UniFi env, or null when the integration isn't configured. */
+export function getUnifiEnv(locals: App.Locals): UnifiEnv | null {
+  const runtime = (locals as { runtime?: { env?: Record<string, unknown> } })
+    .runtime;
+  const env = { ...import.meta.env, ...runtime?.env } as Partial<UnifiEnv>;
+  if (!env.UNIFI_ACCESS_API_URL || !env.UNIFI_ACCESS_API_TOKEN) {
+    return null;
+  }
+  return env as UnifiEnv;
+}
+
+export interface UnifiUser {
+  id: string;
+  first_name?: string;
+  last_name?: string;
+  user_email?: string;
+}
+
+interface Envelope<T> {
+  code: string;
+  msg?: string;
+  data?: T;
+}
+
+/** Max plates a member may register; Access supports multiple per user. */
+export const MAX_PLATES_PER_USER = 4;
+
+async function request<T>(
+  env: UnifiEnv,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T | undefined> {
+  const response = await fetch(
+    `${env.UNIFI_ACCESS_API_URL.replace(/\/$/, "")}/api/v1/developer${path}`,
+    {
+      method,
+      headers: {
+        Authorization: `Bearer ${env.UNIFI_ACCESS_API_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`UniFi Access ${method} ${path} failed: ${response.status}`);
+  }
+  const envelope = (await response.json()) as Envelope<T>;
+  if (envelope.code !== "SUCCESS") {
+    throw new Error(
+      `UniFi Access ${method} ${path} returned ${envelope.code}: ${envelope.msg ?? ""}`,
+    );
+  }
+  return envelope.data;
+}
+
+/**
+ * Finds the Access user whose email matches (case-insensitive). Pages
+ * through the user list; returns null if no match.
+ */
+export async function findUserByEmail(
+  env: UnifiEnv,
+  email: string,
+): Promise<UnifiUser | null> {
+  const target = email.trim().toLowerCase();
+  for (let pageNum = 1; pageNum <= 20; pageNum++) {
+    const users = await request<UnifiUser[]>(
+      env,
+      "GET",
+      `/users?page_num=${pageNum}&page_size=100`,
+    );
+    if (!users?.length) return null;
+    const match = users.find(
+      (user) => user.user_email?.trim().toLowerCase() === target,
+    );
+    if (match) return match;
+    if (users.length < 100) return null;
+  }
+  return null;
+}
+
+/**
+ * License plates come back on the user resource as `license_plates`.
+ * Depending on the Access version they are plain strings or credential
+ * objects — normalize both to display strings.
+ */
+export async function getLicensePlates(
+  env: UnifiEnv,
+  userId: string,
+): Promise<string[]> {
+  const user = await request<
+    UnifiUser & { license_plates?: unknown[] }
+  >(env, "GET", `/users/${encodeURIComponent(userId)}`);
+  return (user?.license_plates ?? [])
+    .map((plate) => {
+      if (typeof plate === "string") return plate;
+      const p = plate as Record<string, unknown>;
+      return String(p.number ?? p.license_plate ?? p.name ?? p.id ?? "");
+    })
+    .filter(Boolean);
+}
+
+/** Replaces the full set of license plates assigned to the user. */
+export async function setLicensePlates(
+  env: UnifiEnv,
+  userId: string,
+  plates: string[],
+): Promise<void> {
+  await request(env, "PUT", `/users/${encodeURIComponent(userId)}/license_plates`, {
+    license_plates: plates,
+  });
+}
+
+/**
+ * Normalizes a plate for storage: uppercase, no whitespace. Returns null
+ * if the result isn't a plausible plate (2-10 chars, A-Z / 0-9 / dash).
+ */
+export function normalizePlate(input: string): string | null {
+  const plate = input.toUpperCase().replace(/\s+/g, "");
+  return /^[A-Z0-9-]{2,10}$/.test(plate) ? plate : null;
+}

--- a/src/lib/unifi.ts
+++ b/src/lib/unifi.ts
@@ -20,21 +20,37 @@
 import { z } from "zod";
 
 export interface UnifiEnv {
-  /** e.g. https://access-api.fallscreekranch.org (fronting <console>:12445) */
+  /** Origin fronting the console's Open API port 12445. */
   UNIFI_ACCESS_API_URL: string;
   /** API token from Access > Settings > General > Advanced > API Token. */
   UNIFI_ACCESS_API_TOKEN: string;
 }
 
-/** Returns the UniFi env, or null when the integration isn't configured. */
+/**
+ * Where the Access API lives. Override with UNIFI_ACCESS_API_URL only if
+ * the tunnel hostname changes — the token is the part that actually has
+ * to be configured, so this keeps setup to a single secret.
+ */
+const DEFAULT_API_URL = "https://gate.fallscreekranch.org";
+
+/**
+ * Returns the UniFi env, or null when the integration isn't configured —
+ * which now means only that the token is absent, since the URL defaults.
+ */
 export function getUnifiEnv(locals: App.Locals): UnifiEnv | null {
   const runtime = (locals as { runtime?: { env?: Record<string, unknown> } })
     .runtime;
-  const env = { ...import.meta.env, ...runtime?.env } as Partial<UnifiEnv>;
-  if (!env.UNIFI_ACCESS_API_URL || !env.UNIFI_ACCESS_API_TOKEN) {
-    return null;
-  }
-  return env as UnifiEnv;
+  const raw = { ...import.meta.env, ...runtime?.env } as Partial<UnifiEnv>;
+
+  // Trimmed for the same reason as the auth secrets: a value pasted into
+  // a dashboard field often arrives with a trailing newline.
+  const token = raw.UNIFI_ACCESS_API_TOKEN?.trim();
+  if (!token) return null;
+
+  return {
+    UNIFI_ACCESS_API_URL: raw.UNIFI_ACCESS_API_URL?.trim() || DEFAULT_API_URL,
+    UNIFI_ACCESS_API_TOKEN: token,
+  };
 }
 
 /**

--- a/src/lib/unifi.ts
+++ b/src/lib/unifi.ts
@@ -2,6 +2,9 @@
  * Minimal UniFi Access developer API client for managing the license
  * plates assigned to a user (used for License Plate Unlock at the gate).
  *
+ * Shapes below follow the UniFi Access API Reference (sections 3.4, 3.5,
+ * 3.28, 3.29). License plate endpoints require Access 3.3.10 or later.
+ *
  * Talks to the Access Open API server (default `https://<console>:12445`,
  * `Authorization: Bearer <token>`, endpoints under `/api/v1/developer`).
  * Every response uses the `{ code, msg, data }` envelope with
@@ -11,13 +14,13 @@
  * Workers cannot skip TLS verification, so `UNIFI_ACCESS_API_URL` must be a
  * publicly resolvable HTTPS endpoint with a valid certificate — in practice
  * a Cloudflare Tunnel in front of the console's 12445 port (the tunnel can
- * `noTLSVerify` the self-signed origin).
+ * `noTLSVerify` the console's self-signed certificate).
  */
 
 export interface UnifiEnv {
   /** e.g. https://access-api.fallscreekranch.org (fronting <console>:12445) */
   UNIFI_ACCESS_API_URL: string;
-  /** API token created in Access > Settings > Security > Advanced. */
+  /** API token from Access > Settings > General > Advanced > API Token. */
   UNIFI_ACCESS_API_TOKEN: string;
 }
 
@@ -32,28 +35,61 @@ export function getUnifiEnv(locals: App.Locals): UnifiEnv | null {
   return env as UnifiEnv;
 }
 
-export interface UnifiUser {
+/** A license plate credential as returned on the user resource. */
+export interface LicensePlate {
+  /** Unique ID of the credential — required to unassign it. */
+  id: string;
+  /** The plate number itself (API field: `credential`). */
+  plate: string;
+  /** `active` or `deactivate`. */
+  status: string;
+}
+
+interface RawLicensePlate {
+  id?: string;
+  credential?: string;
+  credential_type?: string;
+  credential_status?: string;
+}
+
+interface RawUser {
   id: string;
   first_name?: string;
   last_name?: string;
   user_email?: string;
+  /** Present on the search endpoint; absent on users/:id. */
+  email?: string;
+  license_plates?: RawLicensePlate[];
+}
+
+export interface UnifiUser {
+  id: string;
+  email: string;
 }
 
 interface Envelope<T> {
   code: string;
   msg?: string;
   data?: T;
+  pagination?: { page_num: number; page_size: number; total: number };
 }
 
-/** Max plates a member may register; Access supports multiple per user. */
+/**
+ * Plates a member may register through this site. The API documents no
+ * limit — this is our own cap to keep the gate list manageable.
+ */
 export const MAX_PLATES_PER_USER = 4;
+
+const PAGE_SIZE = 100;
+/** Safety valve so a paging bug can't loop against the console forever. */
+const MAX_PAGES = 25;
 
 async function request<T>(
   env: UnifiEnv,
   method: string,
   path: string,
   body?: unknown,
-): Promise<T | undefined> {
+): Promise<Envelope<T>> {
   const response = await fetch(
     `${env.UNIFI_ACCESS_API_URL.replace(/\/$/, "")}/api/v1/developer${path}`,
     {
@@ -75,64 +111,98 @@ async function request<T>(
       `UniFi Access ${method} ${path} returned ${envelope.code}: ${envelope.msg ?? ""}`,
     );
   }
-  return envelope.data;
+  return envelope;
+}
+
+function emailOf(user: RawUser): string {
+  return (user.user_email || user.email || "").trim().toLowerCase();
 }
 
 /**
- * Finds the Access user whose email matches (case-insensitive). Pages
- * through the user list; returns null if no match.
+ * Finds the Access user with a matching email by paging through the user
+ * list. Returns null if no user matches.
  */
 export async function findUserByEmail(
   env: UnifiEnv,
   email: string,
 ): Promise<UnifiUser | null> {
   const target = email.trim().toLowerCase();
-  for (let pageNum = 1; pageNum <= 20; pageNum++) {
-    const users = await request<UnifiUser[]>(
+  if (!target) return null;
+
+  for (let pageNum = 1; pageNum <= MAX_PAGES; pageNum++) {
+    const { data: users, pagination } = await request<RawUser[]>(
       env,
       "GET",
-      `/users?page_num=${pageNum}&page_size=100`,
+      `/users?page_num=${pageNum}&page_size=${PAGE_SIZE}`,
     );
     if (!users?.length) return null;
-    const match = users.find(
-      (user) => user.user_email?.trim().toLowerCase() === target,
-    );
-    if (match) return match;
-    if (users.length < 100) return null;
+
+    const match = users.find((user) => emailOf(user) === target);
+    if (match) return { id: match.id, email: emailOf(match) };
+
+    // Stop once this page covered the last of the reported total, or when
+    // a short page tells us there is nothing more to fetch.
+    const seen = pageNum * PAGE_SIZE;
+    if (users.length < PAGE_SIZE || (pagination && seen >= pagination.total)) {
+      return null;
+    }
   }
   return null;
 }
 
-/**
- * License plates come back on the user resource as `license_plates`.
- * Depending on the Access version they are plain strings or credential
- * objects — normalize both to display strings.
- */
+function toLicensePlate(raw: RawLicensePlate): LicensePlate | null {
+  if (!raw.id || !raw.credential) return null;
+  return {
+    id: raw.id,
+    plate: raw.credential,
+    status: raw.credential_status ?? "active",
+  };
+}
+
+/** Reads the license plates currently assigned to a user (spec 3.4). */
 export async function getLicensePlates(
   env: UnifiEnv,
   userId: string,
-): Promise<string[]> {
-  const user = await request<
-    UnifiUser & { license_plates?: unknown[] }
-  >(env, "GET", `/users/${encodeURIComponent(userId)}`);
+): Promise<LicensePlate[]> {
+  const { data: user } = await request<RawUser>(
+    env,
+    "GET",
+    `/users/${encodeURIComponent(userId)}`,
+  );
   return (user?.license_plates ?? [])
-    .map((plate) => {
-      if (typeof plate === "string") return plate;
-      const p = plate as Record<string, unknown>;
-      return String(p.number ?? p.license_plate ?? p.name ?? p.id ?? "");
-    })
-    .filter(Boolean);
+    .map(toLicensePlate)
+    .filter((plate): plate is LicensePlate => plate !== null);
 }
 
-/** Replaces the full set of license plates assigned to the user. */
-export async function setLicensePlates(
+/**
+ * Assigns license plates to a user (spec 3.28). The body is a bare JSON
+ * array of plate strings, and PUT replaces the collection — so callers
+ * must pass the full desired set, not just the new plate.
+ */
+export async function assignLicensePlates(
   env: UnifiEnv,
   userId: string,
   plates: string[],
 ): Promise<void> {
-  await request(env, "PUT", `/users/${encodeURIComponent(userId)}/license_plates`, {
-    license_plates: plates,
-  });
+  await request(
+    env,
+    "PUT",
+    `/users/${encodeURIComponent(userId)}/license_plates`,
+    plates,
+  );
+}
+
+/** Unassigns a single license plate by its credential ID (spec 3.29). */
+export async function unassignLicensePlate(
+  env: UnifiEnv,
+  userId: string,
+  plateId: string,
+): Promise<void> {
+  await request(
+    env,
+    "DELETE",
+    `/users/${encodeURIComponent(userId)}/license_plates/${encodeURIComponent(plateId)}`,
+  );
 }
 
 /**

--- a/src/lib/unifi.ts
+++ b/src/lib/unifi.ts
@@ -75,6 +75,56 @@ interface Envelope<T> {
 }
 
 /**
+ * A failed Access API call. `code` is the envelope code when the request
+ * reached the API (e.g. `CODE_PARAMS_INVALID`); `status` is the HTTP
+ * status. Both are absent for transport failures such as a timeout.
+ */
+export class UnifiApiError extends Error {
+  constructor(
+    message: string,
+    readonly code?: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "UnifiApiError";
+  }
+
+  /**
+   * True when the failure is a misconfiguration on our side — a bad,
+   * expired, or under-scoped API token. Retrying never helps; an admin
+   * has to fix it, so callers should say so rather than "try again".
+   */
+  get isConfigurationFault(): boolean {
+    return (
+      this.status === 401 ||
+      this.status === 403 ||
+      this.code === "CODE_AUTH_FAILED" ||
+      this.code === "CODE_ACCESS_TOKEN_INVALID" ||
+      this.code === "CODE_UNAUTHORIZED"
+    );
+  }
+
+  /**
+   * True when Access understood the request and refused it — most often a
+   * plate it won't accept, including one already registered to another
+   * user. The API reference documents no license-plate-specific codes
+   * (the CODE_CREDS_* family is NFC only), so this is the closest signal
+   * available for "your input was rejected" rather than "we broke".
+   */
+  get isRejection(): boolean {
+    return (
+      this.code === "CODE_PARAMS_INVALID" ||
+      this.code === "CODE_OPERATION_FORBIDDEN"
+    );
+  }
+}
+
+/** Retried once: rate limiting and transient server-side failures. */
+function isRetryable(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+/**
  * Plates a member may register through this site. The API documents no
  * limit — this is our own cap to keep the gate list manageable.
  */
@@ -84,34 +134,84 @@ const PAGE_SIZE = 100;
 /** Safety valve so a paging bug can't loop against the console forever. */
 const MAX_PAGES = 25;
 
+async function attempt<T>(
+  env: UnifiEnv,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<Envelope<T>> {
+  let response: Response;
+  try {
+    response = await fetch(
+      `${env.UNIFI_ACCESS_API_URL.replace(/\/$/, "")}/api/v1/developer${path}`,
+      {
+        method,
+        headers: {
+          Authorization: `Bearer ${env.UNIFI_ACCESS_API_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+  } catch (error) {
+    // Timeout, DNS failure, TLS failure, connection refused — no response,
+    // so there is no code or status to classify.
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new UnifiApiError(
+      `UniFi Access ${method} ${path} could not be reached: ${reason}`,
+    );
+  }
+
+  if (!response.ok) {
+    // Error responses still carry the envelope, and its code is more
+    // specific than the HTTP status — keep it when it parses.
+    const code = await response
+      .json()
+      .then((parsed) => (parsed as Envelope<T>)?.code)
+      .catch(() => undefined);
+    throw new UnifiApiError(
+      `UniFi Access ${method} ${path} failed: HTTP ${response.status}${code ? ` (${code})` : ""}`,
+      code,
+      response.status,
+    );
+  }
+
+  const envelope = (await response.json()) as Envelope<T>;
+  if (envelope.code !== "SUCCESS") {
+    throw new UnifiApiError(
+      `UniFi Access ${method} ${path} returned ${envelope.code}: ${envelope.msg ?? ""}`,
+      envelope.code,
+      response.status,
+    );
+  }
+  return envelope;
+}
+
+/**
+ * Performs a request, retrying once for rate limiting and transient
+ * server errors. Anything else — including every 4xx that isn't 429 —
+ * fails immediately, since retrying a rejected request just doubles the
+ * load on the console.
+ */
 async function request<T>(
   env: UnifiEnv,
   method: string,
   path: string,
   body?: unknown,
 ): Promise<Envelope<T>> {
-  const response = await fetch(
-    `${env.UNIFI_ACCESS_API_URL.replace(/\/$/, "")}/api/v1/developer${path}`,
-    {
-      method,
-      headers: {
-        Authorization: `Bearer ${env.UNIFI_ACCESS_API_TOKEN}`,
-        "Content-Type": "application/json",
-      },
-      body: body === undefined ? undefined : JSON.stringify(body),
-      signal: AbortSignal.timeout(10_000),
-    },
-  );
-  if (!response.ok) {
-    throw new Error(`UniFi Access ${method} ${path} failed: ${response.status}`);
+  try {
+    return await attempt<T>(env, method, path, body);
+  } catch (error) {
+    const retryable =
+      error instanceof UnifiApiError &&
+      error.status !== undefined &&
+      isRetryable(error.status);
+    if (!retryable) throw error;
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    return attempt<T>(env, method, path, body);
   }
-  const envelope = (await response.json()) as Envelope<T>;
-  if (envelope.code !== "SUCCESS") {
-    throw new Error(
-      `UniFi Access ${method} ${path} returned ${envelope.code}: ${envelope.msg ?? ""}`,
-    );
-  }
-  return envelope;
 }
 
 function emailOf(user: RawUser): string {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,12 +3,16 @@ import { ConfigError, getAuthEnv } from "~/lib/env";
 import { getSessionEmail } from "~/lib/session";
 
 /**
- * Guards the members-only area. Everything under /members requires a valid
- * session cookie (obtained via the magic-link flow at /login).
+ * Guards the members-only area. Pages under /members and API routes under
+ * /api/members require a valid session cookie (obtained via the magic-link
+ * flow at /login); pages redirect to the login form, API routes get a 401.
  */
 export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname } = context.url;
-  if (pathname !== "/members" && !pathname.startsWith("/members/")) {
+  const isMemberPage =
+    pathname === "/members" || pathname.startsWith("/members/");
+  const isMemberApi = pathname.startsWith("/api/members/");
+  if (!isMemberPage && !isMemberApi) {
     return next();
   }
 
@@ -24,6 +28,14 @@ export const onRequest = defineMiddleware(async (context, next) => {
       console.error(
         `Members area is unavailable: ${error.message}. Set these on the Cloudflare project.`,
       );
+      if (isMemberApi) {
+        return new Response(
+          JSON.stringify({
+            message: `Members area is not available yet — missing configuration (${error.keys.join(", ")}).`,
+          }),
+          { status: 503, headers: { "Content-Type": "application/json" } },
+        );
+      }
       // The names ride along so the login page can name them too — /login
       // is a static asset and can only learn this from the URL.
       return context.redirect(
@@ -34,6 +46,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
   }
 
   if (!email) {
+    if (isMemberApi) {
+      return new Response(JSON.stringify({ message: "Sign in required." }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
     return context.redirect("/login/?error=required");
   }
 

--- a/src/pages/api/members/vehicles.ts
+++ b/src/pages/api/members/vehicles.ts
@@ -7,6 +7,7 @@ import {
   MAX_PLATES_PER_USER,
   normalizePlate,
   unassignLicensePlate,
+  UnifiApiError,
 } from "~/lib/unifi";
 
 export const prerender = false;
@@ -35,7 +36,7 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
 
   const env = getUnifiEnv(locals);
   if (!env) {
-    return redirect(back("error"), 303);
+    return redirect(back("unavailable"), 303);
   }
 
   try {
@@ -69,7 +70,20 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
     await unassignLicensePlate(env, user.id, plateId);
     return redirect(back("removed"), 303);
   } catch (error) {
-    console.error("Failed to update license plates:", error);
+    console.error(
+      `Failed to ${action} license plate for ${email}:`,
+      error instanceof Error ? error.message : error,
+    );
+    if (error instanceof UnifiApiError) {
+      // A bad or expired token will never fix itself by retrying, so point
+      // the member at the board instead of telling them to try again.
+      if (error.isConfigurationFault) return redirect(back("unavailable"), 303);
+      // Access understood the request and refused it — most likely the
+      // plate itself, so say so rather than blaming our end.
+      if (error.isRejection && action === "add") {
+        return redirect(back("rejected"), 303);
+      }
+    }
     return redirect(back("error"), 303);
   }
 };

--- a/src/pages/api/members/vehicles.ts
+++ b/src/pages/api/members/vehicles.ts
@@ -1,38 +1,53 @@
 import type { APIRoute } from "astro";
+import { z } from "zod";
 import {
   assignLicensePlates,
   findUserByEmail,
   getLicensePlates,
   getUnifiEnv,
   MAX_PLATES_PER_USER,
-  normalizePlate,
   unassignLicensePlate,
   UnifiApiError,
 } from "~/lib/unifi";
+import { normalizePlate } from "~/lib/plates";
 
 export const prerender = false;
 
 const back = (status: string) => `/members/vehicles?status=${status}`;
+
+/**
+ * The submitted form. Adding carries a plate number to normalize; removing
+ * carries the credential ID of an existing plate. A discriminated union
+ * means each branch only accepts the field it actually uses.
+ */
+const submissionSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("add"),
+    // Normalization is the same shared rule the browser ran, applied here
+    // because the client is never the authority on what is valid.
+    plate: z
+      .string()
+      .transform((value) => normalizePlate(value))
+      .refine((plate): plate is string => plate !== null),
+  }),
+  z.object({
+    action: z.literal("remove"),
+    plate_id: z.string().min(1),
+  }),
+]);
 
 // Session is enforced by src/middleware.ts (401 for /api/members/* without
 // a valid cookie), so locals.user is always set here.
 export const POST: APIRoute = async ({ request, locals, redirect }) => {
   const email = locals.user!.email;
 
-  const form = await request.formData();
-  const action = String(form.get("action") ?? "");
-  if (action !== "add" && action !== "remove") {
+  const submission = submissionSchema.safeParse(
+    Object.fromEntries(await request.formData()),
+  );
+  if (!submission.success) {
     return redirect(back("invalid"), 303);
   }
-
-  // Adding takes a plate number to normalize; removing takes the
-  // credential ID of an existing plate.
-  const plate =
-    action === "add" ? normalizePlate(String(form.get("plate") ?? "")) : null;
-  const plateId = action === "remove" ? String(form.get("plate_id") ?? "") : "";
-  if (action === "add" ? !plate : !plateId) {
-    return redirect(back("invalid"), 303);
-  }
+  const input = submission.data;
 
   const env = getUnifiEnv(locals);
   if (!env) {
@@ -47,8 +62,8 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
 
     const existing = await getLicensePlates(env, user.id);
 
-    if (action === "add") {
-      if (existing.some((entry) => entry.plate.toUpperCase() === plate)) {
+    if (input.action === "add") {
+      if (existing.some((entry) => entry.plate.toUpperCase() === input.plate)) {
         return redirect(back("duplicate"), 303);
       }
       if (existing.length >= MAX_PLATES_PER_USER) {
@@ -57,21 +72,21 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
       // PUT replaces the collection, so send the full desired set.
       await assignLicensePlates(env, user.id, [
         ...existing.map((entry) => entry.plate),
-        plate!,
+        input.plate,
       ]);
       return redirect(back("added"), 303);
     }
 
     // Only remove a plate that actually belongs to this member, so a
     // forged credential ID can't detach someone else's plate.
-    if (!existing.some((entry) => entry.id === plateId)) {
+    if (!existing.some((entry) => entry.id === input.plate_id)) {
       return redirect(back("removed"), 303);
     }
-    await unassignLicensePlate(env, user.id, plateId);
+    await unassignLicensePlate(env, user.id, input.plate_id);
     return redirect(back("removed"), 303);
   } catch (error) {
     console.error(
-      `Failed to ${action} license plate for ${email}:`,
+      `Failed to ${input.action} license plate for ${email}:`,
       error instanceof Error ? error.message : error,
     );
     if (error instanceof UnifiApiError) {
@@ -80,7 +95,7 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
       if (error.isConfigurationFault) return redirect(back("unavailable"), 303);
       // Access understood the request and refused it — most likely the
       // plate itself, so say so rather than blaming our end.
-      if (error.isRejection && action === "add") {
+      if (error.isRejection && input.action === "add") {
         return redirect(back("rejected"), 303);
       }
     }

--- a/src/pages/api/members/vehicles.ts
+++ b/src/pages/api/members/vehicles.ts
@@ -1,0 +1,63 @@
+import type { APIRoute } from "astro";
+import {
+  findUserByEmail,
+  getLicensePlates,
+  getUnifiEnv,
+  MAX_PLATES_PER_USER,
+  normalizePlate,
+  setLicensePlates,
+} from "~/lib/unifi";
+
+export const prerender = false;
+
+const back = (status: string) => `/members/vehicles?status=${status}`;
+
+// Session is enforced by src/middleware.ts (401 for /api/members/* without
+// a valid cookie), so locals.user is always set here.
+export const POST: APIRoute = async ({ request, locals, redirect }) => {
+  const email = locals.user!.email;
+
+  const form = await request.formData();
+  const action = String(form.get("action") ?? "");
+  const plate = normalizePlate(String(form.get("plate") ?? ""));
+  if (!plate || (action !== "add" && action !== "remove")) {
+    return redirect(back("invalid"), 303);
+  }
+
+  const env = getUnifiEnv(locals);
+  if (!env) {
+    return redirect(back("error"), 303);
+  }
+
+  try {
+    const user = await findUserByEmail(env, email);
+    if (!user) {
+      return redirect(back("error"), 303);
+    }
+
+    const plates = await getLicensePlates(env, user.id);
+    if (action === "add") {
+      if (plates.includes(plate)) {
+        return redirect(back("duplicate"), 303);
+      }
+      if (plates.length >= MAX_PLATES_PER_USER) {
+        return redirect(back("limit"), 303);
+      }
+      await setLicensePlates(env, user.id, [...plates, plate]);
+      return redirect(back("added"), 303);
+    }
+
+    if (!plates.includes(plate)) {
+      return redirect(back("removed"), 303);
+    }
+    await setLicensePlates(
+      env,
+      user.id,
+      plates.filter((existing) => existing !== plate),
+    );
+    return redirect(back("removed"), 303);
+  } catch (error) {
+    console.error("Failed to update license plates:", error);
+    return redirect(back("error"), 303);
+  }
+};

--- a/src/pages/api/members/vehicles.ts
+++ b/src/pages/api/members/vehicles.ts
@@ -1,11 +1,12 @@
 import type { APIRoute } from "astro";
 import {
+  assignLicensePlates,
   findUserByEmail,
   getLicensePlates,
   getUnifiEnv,
   MAX_PLATES_PER_USER,
   normalizePlate,
-  setLicensePlates,
+  unassignLicensePlate,
 } from "~/lib/unifi";
 
 export const prerender = false;
@@ -19,8 +20,16 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
 
   const form = await request.formData();
   const action = String(form.get("action") ?? "");
-  const plate = normalizePlate(String(form.get("plate") ?? ""));
-  if (!plate || (action !== "add" && action !== "remove")) {
+  if (action !== "add" && action !== "remove") {
+    return redirect(back("invalid"), 303);
+  }
+
+  // Adding takes a plate number to normalize; removing takes the
+  // credential ID of an existing plate.
+  const plate =
+    action === "add" ? normalizePlate(String(form.get("plate") ?? "")) : null;
+  const plateId = action === "remove" ? String(form.get("plate_id") ?? "") : "";
+  if (action === "add" ? !plate : !plateId) {
     return redirect(back("invalid"), 303);
   }
 
@@ -35,26 +44,29 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
       return redirect(back("error"), 303);
     }
 
-    const plates = await getLicensePlates(env, user.id);
+    const existing = await getLicensePlates(env, user.id);
+
     if (action === "add") {
-      if (plates.includes(plate)) {
+      if (existing.some((entry) => entry.plate.toUpperCase() === plate)) {
         return redirect(back("duplicate"), 303);
       }
-      if (plates.length >= MAX_PLATES_PER_USER) {
+      if (existing.length >= MAX_PLATES_PER_USER) {
         return redirect(back("limit"), 303);
       }
-      await setLicensePlates(env, user.id, [...plates, plate]);
+      // PUT replaces the collection, so send the full desired set.
+      await assignLicensePlates(env, user.id, [
+        ...existing.map((entry) => entry.plate),
+        plate!,
+      ]);
       return redirect(back("added"), 303);
     }
 
-    if (!plates.includes(plate)) {
+    // Only remove a plate that actually belongs to this member, so a
+    // forged credential ID can't detach someone else's plate.
+    if (!existing.some((entry) => entry.id === plateId)) {
       return redirect(back("removed"), 303);
     }
-    await setLicensePlates(
-      env,
-      user.id,
-      plates.filter((existing) => existing !== plate),
-    );
+    await unassignLicensePlate(env, user.id, plateId);
     return redirect(back("removed"), 303);
   } catch (error) {
     console.error("Failed to update license plates:", error);

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -17,37 +17,41 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
     you a sign-in link. No password needed.
   </p>
 
-  <div id="login-error" class="login-alert" role="alert" hidden></div>
+  <div
+    id="login-error"
+    class="form-alert form-alert--error"
+    role="alert"
+    hidden
+  >
+  </div>
 
   <form
     id="login-form"
-    class="login-form"
+    class="form-stack"
     method="post"
     action="/api/auth/request"
   >
-    <label for="email">Email address</label>
+    <label for="email" class="form-label">Email address</label>
     <input
       type="email"
       id="email"
       name="email"
+      class="form-input"
       required
       autocomplete="email"
       placeholder="you@example.com"
     />
-    <button type="submit" id="login-submit">Email me a sign-in link</button>
+    <button type="submit" id="login-submit" class="form-button">
+      Email me a sign-in link
+    </button>
   </form>
 
-  <div
-    id="login-success"
-    class="login-alert login-alert--success"
-    role="status"
-    hidden
-  >
+  <div id="login-success" class="form-alert" role="status" hidden>
     Check your inbox! If that email is in the resident directory, a sign-in
     link is on its way. The link expires in 30 minutes.
   </div>
 
-  <p class="login-help">
+  <p class="form-hint login-help">
     Not receiving a link? Your email may not match the one in the resident
     directory — contact
     <a href="mailto:board@fallscreekranch.org">board@fallscreekranch.org</a>
@@ -56,53 +60,10 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 </StarlightPage>
 
 <style>
-  .login-form {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    max-width: 24rem;
-    margin-top: 1rem;
-  }
-  .login-form label {
-    font-weight: 600;
-  }
-  .login-form input {
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--sl-color-gray-4);
-    border-radius: 0.5rem;
-    background: var(--sl-color-bg);
-    color: var(--sl-color-white);
-    font-size: var(--sl-text-base);
-  }
-  .login-form button {
-    padding: 0.5rem 1rem;
-    border: none;
-    border-radius: 0.5rem;
-    background: var(--sl-color-accent);
-    color: var(--sl-color-black);
-    font-size: var(--sl-text-base);
-    font-weight: 600;
-    cursor: pointer;
-  }
-  .login-form button:disabled {
-    opacity: 0.6;
-    cursor: wait;
-  }
-  .login-alert {
-    margin-top: 1rem;
-    padding: 0.75rem 1rem;
-    border-radius: 0.5rem;
-    background: var(--sl-color-red-low);
-    color: var(--sl-color-red-high);
-  }
-  .login-alert--success {
-    background: var(--sl-color-green-low);
-    color: var(--sl-color-green-high);
-  }
+  /* Controls come from src/styles/forms.css; only page-specific spacing
+     lives here. */
   .login-help {
     margin-top: 1.5rem;
-    font-size: var(--sl-text-sm);
-    color: var(--sl-color-gray-3);
   }
 </style>
 

--- a/src/pages/members/index.astro
+++ b/src/pages/members/index.astro
@@ -21,9 +21,16 @@ const email = Astro.locals.user?.email;
     You are signed in as <strong>{email}</strong>.
   </p>
 
+  <ul>
+    <li>
+      <a href="/members/vehicles">Vehicle license plates</a> — register your
+      plates for automatic gate access.
+    </li>
+  </ul>
+
   <p>
-    Members-only content will appear here. If there is something you would
-    like to see in this area, let the board know at
+    More members-only content will appear here. If there is something you
+    would like to see in this area, let the board know at
     <a href="mailto:board@fallscreekranch.org">board@fallscreekranch.org</a>.
   </p>
 

--- a/src/pages/members/vehicles.astro
+++ b/src/pages/members/vehicles.astro
@@ -5,6 +5,7 @@ import {
   getLicensePlates,
   getUnifiEnv,
   MAX_PLATES_PER_USER,
+  UnifiApiError,
   type LicensePlate,
 } from "~/lib/unifi";
 
@@ -16,6 +17,7 @@ const email = Astro.locals.user!.email;
 type State =
   | { kind: "not-configured" }
   | { kind: "no-account" }
+  | { kind: "misconfigured" }
   | { kind: "error" }
   | { kind: "ok"; plates: LicensePlate[] };
 
@@ -30,8 +32,16 @@ if (!unifiEnv) {
       ? { kind: "ok", plates: await getLicensePlates(unifiEnv, user.id) }
       : { kind: "no-account" };
   } catch (error) {
-    console.error("Failed to load license plates:", error);
-    state = { kind: "error" };
+    console.error(
+      `Failed to load license plates for ${email}:`,
+      error instanceof Error ? error.message : error,
+    );
+    // A rejected token is an admin problem, not a blip — telling the
+    // member to try again later would be a dead end.
+    state =
+      error instanceof UnifiApiError && error.isConfigurationFault
+        ? { kind: "misconfigured" }
+        : { kind: "error" };
   }
 }
 
@@ -43,12 +53,14 @@ const statusMessages: Record<string, string> = {
     "That doesn't look like a valid plate. Use 2-10 letters, numbers, or dashes.",
   duplicate: "That plate is already registered.",
   limit: `You can register up to ${MAX_PLATES_PER_USER} plates. Remove one first.`,
+  rejected:
+    "The gate system wouldn't accept that plate. It may already be registered to another resident — contact board@fallscreekranch.org if you think it should be yours.",
+  unavailable:
+    "The gate system isn't accepting changes right now. This needs an administrator, so please contact board@fallscreekranch.org.",
   error: "Something went wrong saving your change. Please try again later.",
 };
 const statusMessage = status ? statusMessages[status] : undefined;
-const statusIsError = ["invalid", "duplicate", "limit", "error"].includes(
-  status ?? "",
-);
+const statusIsError = status !== "added" && status !== "removed";
 ---
 
 <StarlightPage
@@ -95,6 +107,17 @@ const statusIsError = ["invalid", "duplicate", "limit", "error"].includes(
         Contact
         <a href="mailto:board@fallscreekranch.org"> board@fallscreekranch.org</a>
         to get set up.
+      </p>
+    )
+  }
+
+  {
+    state.kind === "misconfigured" && (
+      <p>
+        The gate system is refusing our connection, which needs an
+        administrator to fix. Please contact
+        <a href="mailto:board@fallscreekranch.org"> board@fallscreekranch.org</a>
+        — trying again later won't help until it's sorted out.
       </p>
     )
   }

--- a/src/pages/members/vehicles.astro
+++ b/src/pages/members/vehicles.astro
@@ -5,6 +5,7 @@ import {
   getLicensePlates,
   getUnifiEnv,
   MAX_PLATES_PER_USER,
+  type LicensePlate,
 } from "~/lib/unifi";
 
 export const prerender = false;
@@ -16,7 +17,7 @@ type State =
   | { kind: "not-configured" }
   | { kind: "no-account" }
   | { kind: "error" }
-  | { kind: "ok"; plates: string[] };
+  | { kind: "ok"; plates: LicensePlate[] };
 
 let state: State;
 const unifiEnv = getUnifiEnv(Astro.locals);
@@ -119,10 +120,13 @@ const statusIsError = ["invalid", "duplicate", "limit", "error"].includes(
           <ul class="plate-list">
             {state.plates.map((plate) => (
               <li>
-                <code>{plate}</code>
+                <code>{plate.plate}</code>
+                {plate.status !== "active" && (
+                  <span class="plate-status">inactive</span>
+                )}
                 <form method="post" action="/api/members/vehicles">
                   <input type="hidden" name="action" value="remove" />
-                  <input type="hidden" name="plate" value={plate} />
+                  <input type="hidden" name="plate_id" value={plate.id} />
                   <button type="submit" class="plate-remove">
                     Remove
                   </button>
@@ -188,6 +192,13 @@ const statusIsError = ["invalid", "duplicate", "limit", "error"].includes(
   }
   .plate-list code {
     font-size: var(--sl-text-lg);
+  }
+  .plate-status {
+    padding: 0.1rem 0.5rem;
+    border-radius: 1rem;
+    background: var(--sl-color-gray-6);
+    color: var(--sl-color-gray-2);
+    font-size: var(--sl-text-xs);
   }
   .plate-remove {
     padding: 0.25rem 0.75rem;

--- a/src/pages/members/vehicles.astro
+++ b/src/pages/members/vehicles.astro
@@ -1,0 +1,240 @@
+---
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+import {
+  findUserByEmail,
+  getLicensePlates,
+  getUnifiEnv,
+  MAX_PLATES_PER_USER,
+} from "~/lib/unifi";
+
+export const prerender = false;
+
+// Set by src/middleware.ts — unauthenticated requests never reach here.
+const email = Astro.locals.user!.email;
+
+type State =
+  | { kind: "not-configured" }
+  | { kind: "no-account" }
+  | { kind: "error" }
+  | { kind: "ok"; plates: string[] };
+
+let state: State;
+const unifiEnv = getUnifiEnv(Astro.locals);
+if (!unifiEnv) {
+  state = { kind: "not-configured" };
+} else {
+  try {
+    const user = await findUserByEmail(unifiEnv, email);
+    state = user
+      ? { kind: "ok", plates: await getLicensePlates(unifiEnv, user.id) }
+      : { kind: "no-account" };
+  } catch (error) {
+    console.error("Failed to load license plates:", error);
+    state = { kind: "error" };
+  }
+}
+
+const status = Astro.url.searchParams.get("status");
+const statusMessages: Record<string, string> = {
+  added: "License plate added. Gate cameras usually pick up changes within a minute.",
+  removed: "License plate removed.",
+  invalid:
+    "That doesn't look like a valid plate. Use 2-10 letters, numbers, or dashes.",
+  duplicate: "That plate is already registered.",
+  limit: `You can register up to ${MAX_PLATES_PER_USER} plates. Remove one first.`,
+  error: "Something went wrong saving your change. Please try again later.",
+};
+const statusMessage = status ? statusMessages[status] : undefined;
+const statusIsError = ["invalid", "duplicate", "limit", "error"].includes(
+  status ?? "",
+);
+---
+
+<StarlightPage
+  frontmatter={{
+    title: "Vehicle License Plates",
+    slug: "members/vehicles",
+    description:
+      "Register your vehicle license plates for gate access at Falls Creek Ranch.",
+    tableOfContents: false,
+    pagefind: false,
+  }}
+>
+  <p>
+    Plates registered here unlock the gate automatically via camera license
+    plate recognition. They are linked to your UniFi Access account
+    (<strong>{email}</strong>).
+  </p>
+
+  {
+    statusMessage && (
+      <div
+        class:list={["plate-alert", { "plate-alert--error": statusIsError }]}
+        role={statusIsError ? "alert" : "status"}
+      >
+        {statusMessage}
+      </div>
+    )
+  }
+
+  {
+    state.kind === "not-configured" && (
+      <p>
+        Vehicle registration isn't available yet — the gate system connection
+        hasn't been configured. Please check back later or contact
+        <a href="mailto:board@fallscreekranch.org"> board@fallscreekranch.org</a>.
+      </p>
+    )
+  }
+
+  {
+    state.kind === "no-account" && (
+      <p>
+        We couldn't find a gate-access account for <strong>{email}</strong>.
+        Contact
+        <a href="mailto:board@fallscreekranch.org"> board@fallscreekranch.org</a>
+        to get set up.
+      </p>
+    )
+  }
+
+  {
+    state.kind === "error" && (
+      <p>
+        We couldn't reach the gate system just now. Please try again later, or
+        contact
+        <a href="mailto:board@fallscreekranch.org"> board@fallscreekranch.org</a>
+        if this keeps happening.
+      </p>
+    )
+  }
+
+  {
+    state.kind === "ok" && (
+      <>
+        <h2>Your registered plates</h2>
+        {state.plates.length === 0 ? (
+          <p>No plates registered yet.</p>
+        ) : (
+          <ul class="plate-list">
+            {state.plates.map((plate) => (
+              <li>
+                <code>{plate}</code>
+                <form method="post" action="/api/members/vehicles">
+                  <input type="hidden" name="action" value="remove" />
+                  <input type="hidden" name="plate" value={plate} />
+                  <button type="submit" class="plate-remove">
+                    Remove
+                  </button>
+                </form>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {state.plates.length < MAX_PLATES_PER_USER && (
+          <form method="post" action="/api/members/vehicles" class="plate-add">
+            <input type="hidden" name="action" value="add" />
+            <label for="plate">Add a plate</label>
+            <div class="plate-add__row">
+              <input
+                type="text"
+                id="plate"
+                name="plate"
+                required
+                maxlength="12"
+                autocomplete="off"
+                placeholder="ABC123"
+              />
+              <button type="submit">Add plate</button>
+            </div>
+            <p class="plate-hint">
+              Letters and numbers only, no state — e.g. <code>ABC123</code>.
+              Up to {MAX_PLATES_PER_USER} plates.
+            </p>
+          </form>
+        )}
+      </>
+    )
+  }
+
+  <p class="plate-back">
+    <a href="/members">&larr; Back to members area</a>
+  </p>
+</StarlightPage>
+
+<style>
+  .plate-alert {
+    margin-top: 1rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    background: var(--sl-color-green-low);
+    color: var(--sl-color-green-high);
+  }
+  .plate-alert--error {
+    background: var(--sl-color-red-low);
+    color: var(--sl-color-red-high);
+  }
+  .plate-list {
+    list-style: none;
+    padding: 0;
+  }
+  .plate-list li {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid var(--sl-color-gray-5);
+  }
+  .plate-list code {
+    font-size: var(--sl-text-lg);
+  }
+  .plate-remove {
+    padding: 0.25rem 0.75rem;
+    border: 1px solid var(--sl-color-gray-4);
+    border-radius: 0.5rem;
+    background: var(--sl-color-bg);
+    color: var(--sl-color-white);
+    font-size: var(--sl-text-sm);
+    cursor: pointer;
+  }
+  .plate-add {
+    margin-top: 1.5rem;
+    max-width: 24rem;
+  }
+  .plate-add label {
+    font-weight: 600;
+  }
+  .plate-add__row {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+  }
+  .plate-add input {
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--sl-color-gray-4);
+    border-radius: 0.5rem;
+    background: var(--sl-color-bg);
+    color: var(--sl-color-white);
+    font-size: var(--sl-text-base);
+    text-transform: uppercase;
+  }
+  .plate-add button {
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 0.5rem;
+    background: var(--sl-color-accent);
+    color: var(--sl-color-black);
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .plate-hint {
+    margin-top: 0.5rem;
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-gray-3);
+  }
+  .plate-back {
+    margin-top: 2rem;
+  }
+</style>

--- a/src/pages/members/vehicles.astro
+++ b/src/pages/members/vehicles.astro
@@ -8,6 +8,7 @@ import {
   UnifiApiError,
   type LicensePlate,
 } from "~/lib/unifi";
+import { PLATE_INPUT_MAXLENGTH, PLATE_RULE_TEXT } from "~/lib/plates";
 
 export const prerender = false;
 
@@ -82,7 +83,7 @@ const statusIsError = status !== "added" && status !== "removed";
   {
     statusMessage && (
       <div
-        class:list={["plate-alert", { "plate-alert--error": statusIsError }]}
+        class:list={["form-alert", { "form-alert--error": statusIsError }]}
         role={statusIsError ? "alert" : "status"}
       >
         {statusMessage}
@@ -150,7 +151,10 @@ const statusIsError = status !== "added" && status !== "removed";
                 <form method="post" action="/api/members/vehicles">
                   <input type="hidden" name="action" value="remove" />
                   <input type="hidden" name="plate_id" value={plate.id} />
-                  <button type="submit" class="plate-remove">
+                  <button
+                    type="submit"
+                    class="form-button form-button--secondary"
+                  >
                     Remove
                   </button>
                 </form>
@@ -160,24 +164,33 @@ const statusIsError = status !== "added" && status !== "removed";
         )}
 
         {state.plates.length < MAX_PLATES_PER_USER && (
-          <form method="post" action="/api/members/vehicles" class="plate-add">
+          <form
+            method="post"
+            action="/api/members/vehicles"
+            class="form-stack plate-add"
+            id="plate-form"
+          >
             <input type="hidden" name="action" value="add" />
-            <label for="plate">Add a plate</label>
-            <div class="plate-add__row">
+            <label for="plate" class="form-label">Add a plate</label>
+            <div class="form-row">
               <input
                 type="text"
                 id="plate"
                 name="plate"
+                class="form-input form-input--plate"
                 required
-                maxlength="12"
+                maxlength={PLATE_INPUT_MAXLENGTH}
                 autocomplete="off"
+                autocapitalize="characters"
+                spellcheck="false"
+                aria-describedby="plate-hint"
                 placeholder="ABC123"
               />
-              <button type="submit">Add plate</button>
+              <button type="submit" class="form-button">Add plate</button>
             </div>
-            <p class="plate-hint">
-              Letters and numbers only, no state — e.g. <code>ABC123</code>.
-              Up to {MAX_PLATES_PER_USER} plates.
+            <p class="form-error" id="plate-error" role="alert" hidden></p>
+            <p class="form-hint" id="plate-hint">
+              {PLATE_RULE_TEXT} No state. Up to {MAX_PLATES_PER_USER} plates.
             </p>
           </form>
         )}
@@ -191,17 +204,8 @@ const statusIsError = status !== "added" && status !== "removed";
 </StarlightPage>
 
 <style>
-  .plate-alert {
-    margin-top: 1rem;
-    padding: 0.75rem 1rem;
-    border-radius: 0.5rem;
-    background: var(--sl-color-green-low);
-    color: var(--sl-color-green-high);
-  }
-  .plate-alert--error {
-    background: var(--sl-color-red-low);
-    color: var(--sl-color-red-high);
-  }
+  /* Controls come from src/styles/forms.css; only the plate list layout
+     is specific to this page. */
   .plate-list {
     list-style: none;
     padding: 0;
@@ -223,52 +227,55 @@ const statusIsError = status !== "added" && status !== "removed";
     color: var(--sl-color-gray-2);
     font-size: var(--sl-text-xs);
   }
-  .plate-remove {
-    padding: 0.25rem 0.75rem;
-    border: 1px solid var(--sl-color-gray-4);
-    border-radius: 0.5rem;
-    background: var(--sl-color-bg);
-    color: var(--sl-color-white);
-    font-size: var(--sl-text-sm);
-    cursor: pointer;
-  }
   .plate-add {
     margin-top: 1.5rem;
-    max-width: 24rem;
-  }
-  .plate-add label {
-    font-weight: 600;
-  }
-  .plate-add__row {
-    display: flex;
-    gap: 0.5rem;
-    margin-top: 0.5rem;
-  }
-  .plate-add input {
-    flex: 1;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--sl-color-gray-4);
-    border-radius: 0.5rem;
-    background: var(--sl-color-bg);
-    color: var(--sl-color-white);
-    font-size: var(--sl-text-base);
-    text-transform: uppercase;
-  }
-  .plate-add button {
-    padding: 0.5rem 1rem;
-    border: none;
-    border-radius: 0.5rem;
-    background: var(--sl-color-accent);
-    color: var(--sl-color-black);
-    font-weight: 600;
-    cursor: pointer;
-  }
-  .plate-hint {
-    margin-top: 0.5rem;
-    font-size: var(--sl-text-sm);
-    color: var(--sl-color-gray-3);
   }
   .plate-back {
     margin-top: 2rem;
   }
 </style>
+
+<script>
+  // Runs the exact same normalize-then-validate function the server uses,
+  // so the two can't disagree about what a valid plate is. Without JS the
+  // form still submits and the server reports the same problem.
+  import { describePlateProblem } from "~/lib/plates";
+
+  const form = document.getElementById("plate-form") as HTMLFormElement | null;
+  const input = document.getElementById("plate") as HTMLInputElement | null;
+  const error = document.getElementById("plate-error");
+
+  if (form && input && error) {
+    const show = (message: string | null) => {
+      error.textContent = message ?? "";
+      error.hidden = message === null;
+      input.setAttribute("aria-invalid", message === null ? "false" : "true");
+    };
+
+    form.addEventListener("submit", (event) => {
+      const problem = describePlateProblem(input.value);
+      if (problem) {
+        event.preventDefault();
+        show(problem);
+        input.focus();
+        return;
+      }
+      show(null);
+      // Guard against a double submit while the gate API call is in
+      // flight; re-enabled on bfcache restore so Back leaves a usable form.
+      const button = form.querySelector<HTMLButtonElement>("button[type=submit]");
+      if (button) button.disabled = true;
+    });
+
+    // Clear a stale complaint as soon as the member starts fixing it.
+    input.addEventListener("input", () => {
+      if (!error.hidden) show(null);
+    });
+  }
+
+  window.addEventListener("pageshow", () => {
+    document
+      .querySelectorAll<HTMLButtonElement>("button[type=submit][disabled]")
+      .forEach((button) => (button.disabled = false));
+  });
+</script>

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -1,0 +1,117 @@
+/**
+ * Shared form controls for the members area (sign-in, vehicle plates).
+ *
+ * These are global classes rather than per-page scoped styles so the two
+ * forms can't drift apart. Everything is expressed in Starlight's design
+ * tokens, so light/dark and the site palette come along for free.
+ */
+@layer starlight, nextjs, forms;
+
+@layer forms {
+  .form-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: 24rem;
+    margin-top: 1rem;
+  }
+
+  .form-label {
+    font-weight: 600;
+  }
+
+  .form-row {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .form-input {
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--sl-color-gray-4);
+    border-radius: 0.5rem;
+    background: var(--sl-color-bg);
+    color: var(--sl-color-white);
+    font-size: var(--sl-text-base);
+    font-family: inherit;
+  }
+
+  .form-input::placeholder {
+    color: var(--sl-color-gray-3);
+  }
+
+  /* Plates read as plates: monospace and uppercased on screen. The typed
+     value still submits as-is — the server normalizes it. */
+  .form-input--plate {
+    font-family: var(--sl-font-mono);
+    text-transform: uppercase;
+  }
+
+  .form-button {
+    padding: 0.5rem 1rem;
+    border: 1px solid transparent;
+    border-radius: 0.5rem;
+    background: var(--sl-color-accent);
+    color: var(--sl-color-black);
+    font-size: var(--sl-text-base);
+    font-family: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .form-button:hover {
+    background: var(--sl-color-accent-high);
+  }
+
+  .form-button--secondary {
+    background: var(--sl-color-bg);
+    border-color: var(--sl-color-gray-4);
+    color: var(--sl-color-white);
+    font-size: var(--sl-text-sm);
+    font-weight: 400;
+    padding: 0.25rem 0.75rem;
+  }
+
+  .form-button--secondary:hover {
+    background: var(--sl-color-gray-6);
+    border-color: var(--sl-color-gray-2);
+  }
+
+  .form-button[disabled] {
+    opacity: 0.6;
+    cursor: wait;
+  }
+
+  /* The rest of the site defines its own focus treatment; without this,
+     these controls would fall back to the browser default. */
+  .form-input:focus-visible,
+  .form-button:focus-visible {
+    outline: 2px solid var(--sl-color-accent-high);
+    outline-offset: 2px;
+  }
+
+  .form-hint {
+    margin-top: 0.5rem;
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-gray-3);
+  }
+
+  .form-error {
+    margin-top: 0.35rem;
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-red-high);
+  }
+
+  .form-alert {
+    margin-top: 1rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    background: var(--sl-color-green-low);
+    color: var(--sl-color-green-high);
+  }
+
+  .form-alert--error {
+    background: var(--sl-color-red-low);
+    color: var(--sl-color-red-high);
+  }
+}


### PR DESCRIPTION
## Summary

Adds `/members/vehicles`, where a signed-in member can register or remove the license plates tied to their UniFi Access account — used for [License Plate Unlock](https://help.ui.com/hc/en-us/articles/23903814413335-Configuring-License-Plate-Unlock-in-UniFi-Access) at the gate. Builds on the magic-link sign-in merged in #79.

## How it works

1. A signed-in member's session email is matched to an Access user by paging `GET /users`
2. The page lists their current plates with per-plate **Remove** buttons and an **Add** form
3. Adds are normalized (uppercase, alphanumeric/dash, 2–10 chars, max 4 plates) and written via the Access API
4. Middleware gates `/api/members/*` — 401 JSON without a session; pages redirect to `/login`

## Verified against the API reference

The endpoint shapes follow the UniFi Access API Reference (§3.4, §3.28, §3.29), which corrected three wrong guesses from my first pass:

- Plate numbers live in `license_plates[].credential`, not `.number` — the original fallback chain ended at `.id`, so the page would have rendered credential UUIDs instead of plates
- Assignment takes a **bare JSON array** of plate strings, not a wrapped object, and PUT *replaces* the collection
- Unassignment is `DELETE /users/:id/license_plates/:plate_id`, not a PUT with the filtered set

License plate endpoints require **UniFi Access 3.3.10 or later**.

## Robustness

- **Zod validates every response.** The console is a trust boundary that can't be exercised from CI, so a version mismatch or an HTML error page from the tunnel raises `UnifiSchemaError` naming the exact field (e.g. `license_plates.0.credential: Required`) rather than silently rendering an empty list. Schemas are non-strict, so a newer Access adding fields can't break us.
- **Failures are classified.** An expired token points the member at the board (retrying can't fix it); a rejected plate says so; 429 and 5xx retry once, other 4xx fail fast. Every call carries a 10s timeout.
- **Form input** uses a discriminated union, so each branch accepts only its own fields.
- **Removals verify ownership** — a forged credential ID can't detach someone else's plate.

## Configuration

Only **`UNIFI_ACCESS_API_TOKEN`** is required (Access → Settings → General → Advanced → API Token, with `view:user` and `edit:user` scopes). Until it's set, the page shows a "not available yet" notice, so this merges safely ahead of the console being wired up.

`UNIFI_ACCESS_API_URL` defaults to `https://gate.fallscreekranch.org` and only needs setting if that hostname changes. It must be publicly reachable HTTPS with a valid certificate fronting the console's port 12445 — the Worker runs with `global_fetch_strictly_public` and cannot skip TLS verification, so the console's own self-signed cert on `<ip>:12445` will not work.

## Also included

- Shared form styling (`src/styles/forms.css`) so the sign-in and plates forms can't drift apart, plus the `:focus-visible` states they were missing
- `src/lib/plates.ts` holds the single definition of a valid plate — dependency-free, so the identical rule runs in the SSR page, the API route, and the browser (~300 bytes inlined) instead of being restated as an HTML `pattern` that could disagree with the server
- Client-side validation and a double-submit guard, both progressive enhancements: without JS the form still posts and the server reports the same problem

## Testing

- `pnpm build` and `npx tsc --noEmit` both clean
- Smoke-tested end to end against a mock of the Access API: auth gating, listing, add with normalization, remove, duplicate and limit handling, forged-ID rejection, and the unconfigured state
- Schema failures verified by pointing the mock at the *previous wrong shape* and at an HTML error page — both caught and logged with the offending field
- Not tested against a real console; that's the first thing to exercise after merge