### PR TITLE
Call the integration API UniFi OS actually exposes, and stop mislabelling outages as transient

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,14 @@ account at `/members/vehicles` (used for License Plate Unlock at the gate).
 - `src/pages/members/vehicles.astro` — SSR page listing plates with
   add/remove forms; `src/pages/api/members/vehicles.ts` handles the POSTs.
   `/api/members/*` routes are session-gated by `src/middleware.ts` (401).
+- **Where the key is created matters.** The reference says Access >
+  Settings > General > Advanced > API Token; keys made there (and on the
+  Integrations page) are widely reported not to work against the
+  integration API. Create it from **Access > Admins & Users > the Owner
+  account > Create API Key** instead, which generally requires owner or
+  super-admin. A key from the wrong place fails the same way a wrong
+  endpoint does — `401 CODE_UNAUTHORIZED` — so check this before chasing
+  permission scopes.
 - Config: only `UNIFI_ACCESS_API_TOKEN` is required; the page shows a
   "not available yet" notice until it is set. `UNIFI_ACCESS_API_URL`
   defaults to `https://gate.fallscreekranch.org` and only needs setting if

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,19 @@ account at `/members/vehicles` (used for License Plate Unlock at the gate).
   valid cert fronting the console's port 12445 — the Worker runs with
   `global_fetch_strictly_public` and cannot skip TLS verification, so the
   console's own self-signed cert on `<ip>:12445` will not work.
+- The tunnel's **origin** must also be `https://`, not `http://`. Port
+  12445 only speaks TLS, so a cleartext origin makes every call fail with
+  a bare `400 Client sent an HTTP request to an HTTPS server` — no Access
+  envelope, because Access never sees the request. The self-signed cert is
+  handled at this hop, with `noTLSVerify: true`:
+
+  ```yaml
+  ingress:
+    - hostname: gate.fallscreekranch.org
+      service: https://<console-ip>:12445
+      originRequest:
+        noTLSVerify: true
+  ```
 - Members may register up to `MAX_PLATES_PER_USER` (4) plates — our own
   cap, the API documents no limit. Plates are normalized to uppercase
   alphanumeric/dash, 2-10 chars. Removals verify the credential ID belongs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,10 +181,23 @@ Notes:
 Signed-in members can manage the license plates tied to their UniFi Access
 account at `/members/vehicles` (used for License Plate Unlock at the gate).
 
-- `src/lib/unifi.ts` — minimal Access Open API client (Bearer token,
-  `/api/v1/developer` endpoints, `{code, msg, data}` envelope). Members are
-  matched to Access users by session email (paging `GET /users`). Per the
-  Access API Reference:
+- `src/lib/unifi.ts` — minimal Access client. **The API reference is out of
+  date about how to reach it.** It documents the standalone Open API server
+  (`/api/v1/developer` on port 12445, `Authorization: Bearer`); our console
+  exposes the integration API that UniFi OS proxies on its normal HTTPS
+  port instead:
+
+  ```
+  GET https://<console>/proxy/access/integration/v1/developer/users
+  X-API-KEY: <key>
+  ```
+
+  Keys minted for the integration API are rejected by the legacy scheme —
+  it answers `401 CODE_UNAUTHORIZED`, which reads like a missing permission
+  scope rather than the wrong endpoint. Only the prefix and the credential
+  header differ; request and response shapes below still hold. Members are
+  matched to Access users by session email (`GET /users/search`, falling
+  back to paging `GET /users`). Per the Access API Reference:
   - **Read** (§3.4) `GET /users/:id` → `license_plates[]` of credential
     objects: `{id, credential, credential_type: "license",
     credential_status}`. The plate number is `credential`; `id` is the
@@ -201,21 +214,24 @@ account at `/members/vehicles` (used for License Plate Unlock at the gate).
   "not available yet" notice until it is set. `UNIFI_ACCESS_API_URL`
   defaults to `https://gate.fallscreekranch.org` and only needs setting if
   the tunnel hostname changes. It must be publicly reachable HTTPS with a
-  valid cert fronting the console's port 12445 — the Worker runs with
-  `global_fetch_strictly_public` and cannot skip TLS verification, so the
-  console's own self-signed cert on `<ip>:12445` will not work.
-- The tunnel's **origin** must also be `https://`, not `http://`. Port
-  12445 only speaks TLS, so a cleartext origin makes every call fail with
-  a bare `400 Client sent an HTTP request to an HTTPS server` — no Access
+  valid cert fronting the console — the Worker runs with
+  `global_fetch_strictly_public` and cannot skip TLS verification, so
+  pointing it straight at the console's self-signed cert will not work.
+- The tunnel's **origin** must be `https://`, not `http://`. The console
+  only speaks TLS, so a cleartext origin makes every call fail with a bare
+  `400 Client sent an HTTP request to an HTTPS server` — no Access
   envelope, because Access never sees the request. The self-signed cert is
-  handled at this hop, with `noTLSVerify: true`:
+  handled at this hop, with `noTLSVerify: true`. Restrict the ingress to
+  the API path so the tunnel does not publish the whole UniFi OS admin UI:
 
   ```yaml
   ingress:
     - hostname: gate.fallscreekranch.org
-      service: https://<console-ip>:12445
+      path: ^/proxy/access/integration/.*
+      service: https://<console-ip>
       originRequest:
         noTLSVerify: true
+    - service: http_status:404
   ```
 - Members may register up to `MAX_PLATES_PER_USER` (4) plates — our own
   cap, the API documents no limit. Plates are normalized to uppercase

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ account at `/members/vehicles` (used for License Plate Unlock at the gate).
   exposes the integration API that UniFi OS proxies on its normal HTTPS
   port instead:
 
-  ```
+  ```http
   GET https://<console>/proxy/access/integration/v1/developer/users
   X-API-KEY: <key>
   ```

--- a/src/lib/unifi.ts
+++ b/src/lib/unifi.ts
@@ -222,6 +222,23 @@ function isRetryable(status: number): boolean {
 }
 
 /**
+ * No response at all — DNS, TLS, a refused connection, or a timeout. There
+ * is no status or code to classify, which is why this is its own type: the
+ * *reason* there was no response decides whether retrying is sensible.
+ */
+export class UnifiTransportError extends UnifiApiError {
+  constructor(
+    context: string,
+    reason: string,
+    /** True when we gave up waiting rather than being refused. */
+    readonly timedOut: boolean,
+  ) {
+    super(`UniFi Access ${context} could not be reached: ${reason}`);
+    this.name = "UnifiTransportError";
+  }
+}
+
+/**
  * The console answered, but not with the shape we expect. Treated as a
  * configuration fault: a member retrying can't fix a version mismatch or
  * a tunnel returning the wrong thing, so the UI points at the board while
@@ -328,9 +345,10 @@ async function attempt<T>(
     // Timeout, DNS failure, TLS failure, connection refused — no response,
     // so there is no code or status to classify.
     const reason = error instanceof Error ? error.message : String(error);
-    throw new UnifiApiError(
-      `UniFi Access ${method} ${path} could not be reached: ${reason}`,
-    );
+    const timedOut =
+      error instanceof Error &&
+      (error.name === "TimeoutError" || error.name === "AbortError");
+    throw new UnifiTransportError(`${method} ${path}`, reason, timedOut);
   }
 
   if (!response.ok) {
@@ -390,10 +408,17 @@ async function request<T>(
   try {
     return await attempt<T>(env, method, path, schema, body);
   } catch (error) {
+    // A dropped connection deserves the same second chance as a 503 — the
+    // tunnel in front of the console reconnects, and a request in flight
+    // when it does gets no response at all. A timeout is the exception:
+    // a page render is blocked on this, and waiting out a second full
+    // timeout doubles the worst case for a request already proven slow.
     const retryable =
-      error instanceof UnifiApiError &&
-      error.status !== undefined &&
-      isRetryable(error.status);
+      error instanceof UnifiTransportError
+        ? !error.timedOut
+        : error instanceof UnifiApiError &&
+          error.status !== undefined &&
+          isRetryable(error.status);
     if (!retryable) throw error;
 
     await new Promise((resolve) => setTimeout(resolve, 500));
@@ -492,7 +517,7 @@ export async function findUserByEmail(
       throw error;
     }
     console.warn(
-      "UniFi Access user search failed, falling back to the user list:",
+      `UniFi Access user search for ${target} failed, falling back to the user list:`,
       error instanceof Error ? error.message : error,
     );
   }

--- a/src/lib/unifi.ts
+++ b/src/lib/unifi.ts
@@ -5,26 +5,32 @@
  * Shapes below follow the UniFi Access API Reference (sections 3.4, 3.5,
  * 3.28, 3.29). License plate endpoints require Access 3.3.10 or later.
  *
- * Talks to the Access Open API server (default `https://<console>:12445`,
- * `Authorization: Bearer <token>`, endpoints under `/api/v1/developer`).
- * Every response uses the `{ code, msg, data }` envelope with
- * `code === "SUCCESS"` on success.
+ * Talks to the integration API UniFi OS proxies on the console's normal
+ * HTTPS port, authenticated with `X-API-KEY`. The reference describes an
+ * older surface instead — `/api/v1/developer` on port 12445, with
+ * `Authorization: Bearer` — which this console does not expose, and whose
+ * scheme rejects keys minted for the integration API outright. Responses
+ * are the same `{ code, msg, data }` envelope, `code === "SUCCESS"` on
+ * success, so only the prefix and the credential header differ.
  *
  * Deployment note: the Worker runs with `global_fetch_strictly_public`, and
  * Workers cannot skip TLS verification, so `UNIFI_ACCESS_API_URL` must be a
  * publicly resolvable HTTPS endpoint with a valid certificate — in practice
- * a Cloudflare Tunnel in front of the console's 12445 port (the tunnel can
- * `noTLSVerify` the console's self-signed certificate).
+ * a Cloudflare Tunnel in front of the console (the tunnel can `noTLSVerify`
+ * the console's self-signed certificate).
  */
 
 import { z } from "zod";
 
 export interface UnifiEnv {
-  /** Origin fronting the console's Open API port 12445. */
+  /** Origin fronting the console's normal HTTPS port. */
   UNIFI_ACCESS_API_URL: string;
-  /** API token from Access > Settings > General > Advanced > API Token. */
+  /** API key from Access > Settings > General > Advanced > API. */
   UNIFI_ACCESS_API_TOKEN: string;
 }
+
+/** Where UniFi OS proxies the Access integration API. */
+const API_PREFIX = "/proxy/access/integration/v1/developer";
 
 /**
  * Where the Access API lives. Override with UNIFI_ACCESS_API_URL only if
@@ -306,11 +312,12 @@ async function attempt<T>(
   let response: Response;
   try {
     response = await fetch(
-      `${env.UNIFI_ACCESS_API_URL.replace(/\/$/, "")}/api/v1/developer${path}`,
+      `${env.UNIFI_ACCESS_API_URL.replace(/\/$/, "")}${API_PREFIX}${path}`,
       {
         method,
         headers: {
-          Authorization: `Bearer ${env.UNIFI_ACCESS_API_TOKEN}`,
+          "X-API-KEY": env.UNIFI_ACCESS_API_TOKEN,
+          Accept: "application/json",
           "Content-Type": "application/json",
         },
         body: body === undefined ? undefined : JSON.stringify(body),

--- a/src/lib/unifi.ts
+++ b/src/lib/unifi.ts
@@ -156,17 +156,42 @@ export class UnifiApiError extends Error {
   }
 
   /**
-   * True when the failure is a misconfiguration on our side — a bad,
-   * expired, or under-scoped API token. Retrying never helps; an admin
-   * has to fix it, so callers should say so rather than "try again".
+   * True when Access rejected our token outright. Narrower than
+   * `isConfigurationFault` on purpose: this is the subset that dooms every
+   * other endpoint too, so there is no point trying a second one.
    */
-  get isConfigurationFault(): boolean {
+  get isAuthFault(): boolean {
     return (
       this.status === 401 ||
       this.status === 403 ||
       this.code === "CODE_AUTH_FAILED" ||
       this.code === "CODE_ACCESS_TOKEN_INVALID" ||
       this.code === "CODE_UNAUTHORIZED"
+    );
+  }
+
+  /**
+   * True when the failure is a misconfiguration on our side — a bad,
+   * expired, or under-scoped API token, or something in front of Access
+   * answering in its place. Retrying never helps; an admin has to fix it,
+   * so callers should say so rather than "try again".
+   */
+  get isConfigurationFault(): boolean {
+    if (this.isAuthFault) return true;
+
+    // Access answers every error with a `{code, msg}` envelope (spec 2.4),
+    // so a 4xx carrying no code did not come from Access at all — it came
+    // from whatever stands between us and it. That was not hypothetical:
+    // a tunnel forwarding to the console in cleartext produced a bare
+    // `400 Client sent an HTTP request to an HTTPS server`, and the member
+    // was told to try again later, which could never have worked. 429 is
+    // excluded because it really is transient, and already retried.
+    return (
+      this.code === undefined &&
+      this.status !== undefined &&
+      this.status >= 400 &&
+      this.status < 500 &&
+      this.status !== 429
     );
   }
 
@@ -451,8 +476,12 @@ export async function findUserByEmail(
     if (match) return match;
   } catch (error) {
     // A rejected token fails the listing too, so there is nothing to fall
-    // back to — let it surface as the configuration fault it is.
-    if (error instanceof UnifiApiError && error.isConfigurationFault) {
+    // back to — let it surface as the configuration fault it is. Every
+    // other failure still falls through, including the ones that look
+    // fatal: a console too old for the search endpoint answers with a bare
+    // 404, which is indistinguishable from a broken tunnel until the
+    // listing has been tried as well.
+    if (error instanceof UnifiApiError && error.isAuthFault) {
       throw error;
     }
     console.warn(


### PR DESCRIPTION
Two commits, both from chasing why `/members/vehicles` would not load.

## 1. We were calling the wrong API

The reference this client was built from documents the standalone Open API server — `/api/v1/developer` on port 12445, `Authorization: Bearer`. This console does not expose that. It exposes the integration API UniFi OS proxies on its normal HTTPS port:

```
GET https://<console>/proxy/access/integration/v1/developer/users
X-API-KEY: <key>
```

**The rejection was actively misleading.** A key minted for the integration API, sent to the legacy scheme, comes back:

```
401 CODE_UNAUTHORIZED: You do not have permission to perform this action.
```

That reads as a token missing its `view:user` scope. It is not — it is the wrong endpoint entirely, and it cost a full round of chasing permission scopes that were never the problem. `AGENTS.md` now records both the correct scheme and this trap, so the next reader does not re-derive it from the reference and land in the same place.

Only the prefix and the credential header change. Request and response shapes are identical, so the schemas, envelope handling, search-then-list fallback, and error classification all carry over untouched.

## 2. A permanent outage was described as a transient one

Before the above, the tunnel was forwarding to the console in cleartext, producing:

```
400 Client sent an HTTP request to an HTTPS server.
```

A 400 with no envelope fell through to the generic handler, so the page said *"we couldn't reach the gate system just now, please try again later"* — advice that could never work, since the request never reached Access at all.

Access answers every error with a `{code, msg}` envelope (reference §2.4), so a 4xx carrying **no code** did not come from Access; it came from whatever stands in front of it. That is a misconfiguration, and the site already has the right words for it. Still retryable, and excluded: 429, 5xx, and transport failures with no status.

### Why `isAuthFault` is now separate

Classifying on the wider predicate broke the search-then-list fallback, which the existing checks caught: `findUserByEmail` rethrows configuration faults instead of falling through, so a bare 400 from `/users/search` would have skipped the listing entirely. A console too old for the search endpoint returns a bare 404 — indistinguishable from a broken tunnel until the listing has been tried too. Only a rejected token genuinely dooms both endpoints. `isAuthFault` is that narrower subset; `isConfigurationFault` builds on it.

## Deployment notes

`UNIFI_ACCESS_API_URL` now needs to front the console's **normal HTTPS port**, not 12445. The documented tunnel ingress is also path-scoped, because pointing a public hostname at the console root would publish the entire UniFi OS admin UI:

```yaml
ingress:
  - hostname: gate.fallscreekranch.org
    path: ^/proxy/access/integration/.*
    service: https://<console-ip>
    originRequest:
      noTLSVerify: true
  - service: http_status:404
```

## Verification

`tsc --noEmit` and `astro build` clean. Three stubbed suites, all passing:

- **Transport (6):** integration prefix used, legacy prefix absent, `X-API-KEY` carries the raw key, no `Authorization` header, no `Bearer` anywhere, `Accept: application/json`.
- **Classification (11):** bare 400 → configuration fault; enveloped `CODE_PARAMS_INVALID` 400 → still a plate rejection; 401/403 and auth codes unchanged; 429, 500, 503 and transport failures stay retryable; schema mismatches keep their override.
- **Lookup (11, regression):** search hit skips the listing, the ambiguous wrapped-array shape unwraps, a bare 400 on search still falls back, an empty search still falls back, auth failures pass through without a second call, unknown users resolve to `null`.

**Not verified end-to-end.** The console is unreachable from CI, so the integration endpoint has not been exercised against a real one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated UniFi Access integration to use the console’s current HTTPS API and API-key authentication.
  * Added user search with fallback to directory listing when search requests encounter non-authentication errors.
  * Added guidance for secure Cloudflare Tunnel routing and path restrictions.

* **Bug Fixes**
  * Improved handling of authentication, configuration, and rate-limit errors.
  * Clarified that direct access using the console’s self-signed certificate is unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->