### PR TITLE
Use the Access Open-API (12445 + Bearer), the scheme that actually works on our console

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,21 +181,22 @@ Notes:
 Signed-in members can manage the license plates tied to their UniFi Access
 account at `/members/vehicles` (used for License Plate Unlock at the gate).
 
-- `src/lib/unifi.ts` — minimal Access client. **The API reference is out of
-  date about how to reach it.** It documents the standalone Open API server
-  (`/api/v1/developer` on port 12445, `Authorization: Bearer`); our console
-  exposes the integration API that UniFi OS proxies on its normal HTTPS
-  port instead:
+- `src/lib/unifi.ts` — minimal Access client. Uses the Access **Open-API
+  server on port 12445** with `Authorization: Bearer`, under
+  `/api/v1/developer`:
 
   ```http
-  GET https://<console>/proxy/access/integration/v1/developer/users
-  X-API-KEY: <key>
+  GET https://<console>:12445/api/v1/developer/users
+  Authorization: Bearer <token>
   ```
 
-  Keys minted for the integration API are rejected by the legacy scheme —
-  it answers `401 CODE_UNAUTHORIZED`, which reads like a missing permission
-  scope rather than the wrong endpoint. Only the prefix and the credential
-  header differ; request and response shapes below still hold. Members are
+  This is the reference's documented surface, and — despite newer docs
+  advertising the UniFi OS integration API (`/proxy/access/integration/...`
+  with `X-API-KEY`) — the one that actually authenticates on our console.
+  The integration path was tried and reverted: it answers a UniFi OS
+  `{"error":{"code":401}}` for every token we hold, verified directly on
+  the console over loopback, while Bearer/12445 works and is what the
+  sibling `fcr-gate` service uses against the same console. Members are
   matched to Access users by session email (`GET /users/search`, falling
   back to paging `GET /users`). Per the Access API Reference:
   - **Read** (§3.4) `GET /users/:id` → `license_plates[]` of credential
@@ -210,33 +211,30 @@ account at `/members/vehicles` (used for License Plate Unlock at the gate).
 - `src/pages/members/vehicles.astro` — SSR page listing plates with
   add/remove forms; `src/pages/api/members/vehicles.ts` handles the POSTs.
   `/api/members/*` routes are session-gated by `src/middleware.ts` (401).
-- **Where the key is created matters.** The reference says Access >
-  Settings > General > Advanced > API Token; keys made there (and on the
-  Integrations page) are widely reported not to work against the
-  integration API. Create it from **Access > Admins & Users > the Owner
-  account > Create API Key** instead, which generally requires owner or
-  super-admin. A key from the wrong place fails the same way a wrong
-  endpoint does — `401 CODE_UNAUTHORIZED` — so check this before chasing
-  permission scopes.
+- **The token is the one `fcr-gate` already uses.** Do not mint a new one:
+  the working Access Open-API token lives on the gate host at
+  `/data/fcr-gate/secrets/unifi-access-api-key` (set via `UNIFI_API_KEY_FILE`
+  in `/data/fcr-gate/secrets/gateway.env`). Copy that value into the site's
+  `UNIFI_ACCESS_API_TOKEN`. Keys created from the UniFi OS Control-Plane /
+  Integrations pages authenticate the integration API, not this Open-API
+  server, and fail here with a UniFi OS `{"error":{"code":401}}`.
 - Config: only `UNIFI_ACCESS_API_TOKEN` is required; the page shows a
   "not available yet" notice until it is set. `UNIFI_ACCESS_API_URL`
   defaults to `https://gate.fallscreekranch.org` and only needs setting if
   the tunnel hostname changes. It must be publicly reachable HTTPS with a
-  valid cert fronting the console — the Worker runs with
+  valid cert fronting the console's `:12445` — the Worker runs with
   `global_fetch_strictly_public` and cannot skip TLS verification, so
   pointing it straight at the console's self-signed cert will not work.
-- The tunnel's **origin** must be `https://`, not `http://`. The console
-  only speaks TLS, so a cleartext origin makes every call fail with a bare
-  `400 Client sent an HTTP request to an HTTPS server` — no Access
-  envelope, because Access never sees the request. The self-signed cert is
-  handled at this hop, with `noTLSVerify: true`. Restrict the ingress to
-  the API path so the tunnel does not publish the whole UniFi OS admin UI:
+- The tunnel's **origin** must be `https://<console-ip>:12445`, not `http://`
+  and not port 443. Port 12445 only speaks TLS, so a cleartext origin makes
+  every call fail with a bare `400 Client sent an HTTP request to an HTTPS
+  server` — no Access envelope, because Access never sees the request. The
+  self-signed cert is handled at this hop, with `noTLSVerify: true`:
 
   ```yaml
   ingress:
     - hostname: gate.fallscreekranch.org
-      path: ^/proxy/access/integration/.*
-      service: https://<console-ip>
+      service: https://<console-ip>:12445
       originRequest:
         noTLSVerify: true
     - service: http_status:404

--- a/src/lib/unifi.ts
+++ b/src/lib/unifi.ts
@@ -5,19 +5,23 @@
  * Shapes below follow the UniFi Access API Reference (sections 3.4, 3.5,
  * 3.28, 3.29). License plate endpoints require Access 3.3.10 or later.
  *
- * Talks to the integration API UniFi OS proxies on the console's normal
- * HTTPS port, authenticated with `X-API-KEY`. The reference describes an
- * older surface instead — `/api/v1/developer` on port 12445, with
- * `Authorization: Bearer` — which this console does not expose, and whose
- * scheme rejects keys minted for the integration API outright. Responses
- * are the same `{ code, msg, data }` envelope, `code === "SUCCESS"` on
- * success, so only the prefix and the credential header differ.
+ * Talks to the Access Open-API server on the console's port 12445,
+ * authenticated with `Authorization: Bearer`, under `/api/v1/developer`.
+ *
+ * This is the reference's documented surface, and — despite what the newer
+ * docs advertise — the one that actually authenticates on our console. The
+ * UniFi OS integration API (`/proxy/access/integration/...` with
+ * `X-API-KEY`) rejects every token we hold with a UniFi OS `{error:...}`
+ * 401, checked directly on the console over loopback; the Bearer/12445 path
+ * is proven, and is what the sibling `fcr-gate` service uses against the
+ * same console. Responses are the `{ code, msg, data }` envelope, with
+ * `code === "SUCCESS"` on success.
  *
  * Deployment note: the Worker runs with `global_fetch_strictly_public`, and
  * Workers cannot skip TLS verification, so `UNIFI_ACCESS_API_URL` must be a
  * publicly resolvable HTTPS endpoint with a valid certificate — in practice
- * a Cloudflare Tunnel in front of the console (the tunnel can `noTLSVerify`
- * the console's self-signed certificate).
+ * a Cloudflare Tunnel whose origin points at the console's `:12445` (the
+ * tunnel can `noTLSVerify` the console's self-signed certificate).
  */
 
 import { z } from "zod";
@@ -25,12 +29,20 @@ import { z } from "zod";
 export interface UnifiEnv {
   /** Origin fronting the console's normal HTTPS port. */
   UNIFI_ACCESS_API_URL: string;
-  /** API key from Access > Settings > General > Advanced > API. */
+  /** Access Open-API token (Access > Settings > General > Advanced). */
   UNIFI_ACCESS_API_TOKEN: string;
 }
 
-/** Where UniFi OS proxies the Access integration API. */
-const API_PREFIX = "/proxy/access/integration/v1/developer";
+/**
+ * Where the Access Open-API server serves the developer endpoints, on the
+ * console's port 12445. This console does NOT authenticate the UniFi OS
+ * integration API (`/proxy/access/integration/...` with `X-API-KEY`) — that
+ * path returns a UniFi OS `{error:{code:401}}` for every token we have,
+ * verified against the console over loopback. The Open-API server on 12445,
+ * authenticated with `Authorization: Bearer`, is the one that works, and is
+ * what the sibling `fcr-gate` service uses against the same console.
+ */
+const API_PREFIX = "/api/v1/developer";
 
 /**
  * Where the Access API lives. Override with UNIFI_ACCESS_API_URL only if
@@ -333,7 +345,7 @@ async function attempt<T>(
       {
         method,
         headers: {
-          "X-API-KEY": env.UNIFI_ACCESS_API_TOKEN,
+          Authorization: `Bearer ${env.UNIFI_ACCESS_API_TOKEN}`,
           Accept: "application/json",
           "Content-Type": "application/json",
         },


### PR DESCRIPTION
The integration-API switch in #83 was based on community docs, not on our console. It does not authenticate here. This reverts the transport to the Open-API scheme, which is proven.

## Evidence (on the console, over loopback — no tunnel, no Cloudflare)

```
# 443 integration API, X-API-KEY  → UniFi OS gateway rejects the key
HTTP 401  {"error":{"code":401,"message":"Unauthorized"}}

# 12445 Open API, Bearer          → reaches Access itself
HTTP 401  {"code":"CODE_UNAUTHORIZED","msg":"You do not have permission..."}
```

The error **shapes** are the proof. The integration path answers a UniFi OS `{"error":{"code":401}}`, so the request never reaches Access — the gateway refuses the key type. The Open-API path answers the Access `{"code","msg"}` envelope, so Access saw it. And the sibling **`fcr-gate`** service authenticates against this same console on 12445 + Bearer and works in production — so the scheme is demonstrated, not guessed.

(The `CODE_UNAUTHORIZED` above was a wrong *token* during testing, not a wrong scheme — the point is only that the request reached Access. The real token, below, is accepted.)

## What changes

Transport only:

- `API_PREFIX`: `/proxy/access/integration/v1/developer` → `/api/v1/developer`
- Auth header: `X-API-KEY` → `Authorization: Bearer`

Everything #83 added on top is scheme-independent and stays: the `isAuthFault` split, transport-failure retry, `describeFailure` diagnostics, and the search-then-list fallback. Request/response shapes are identical between the two surfaces, so schemas and envelope handling are untouched.

## Deployment (both required, or it stays broken)

1. **Token** — reuse the one `fcr-gate` already uses. It lives on the gate host at `/data/fcr-gate/secrets/unifi-access-api-key` (loaded via `UNIFI_API_KEY_FILE`). Copy that value into the site's `UNIFI_ACCESS_API_TOKEN`. It is an Access Open-API bearer token (Access → Settings → General → Advanced → API Token), **not** a UniFi OS Control-Plane / Integrations key — those are what the 443 path wanted, and what this console rejected.
2. **Tunnel** — point the origin at the console's **`:12445`**, not 443:

   ```yaml
   ingress:
     - hostname: gate.fallscreekranch.org
       service: https://<console-ip>:12445
       originRequest:
         noTLSVerify: true
     - service: http_status:404
   ```

## Verification

`tsc --noEmit` and `astro build` clean. Three stubbed suites, all passing:

- **Transport (5):** Open-API prefix, no integration prefix, `Authorization: Bearer <raw token>`, no `X-API-KEY`, `Accept: application/json`.
- **Classification (11):** bare 4xx → configuration fault, enveloped `CODE_PARAMS_INVALID` → plate rejection, auth codes/statuses, 429/5xx/transport stay retryable.
- **Lookup (11):** search hit skips the listing, wrapped-array unwrap, 400/empty search fall back, auth passes through, unknown → `null`.

Not exercised against the live console from CI — but this is the scheme fcr-gate runs in production against it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bp5FYFyTpUmodzipjWRu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated UniFi Access connectivity to use the Access Open API with Bearer-token authentication.
  - Added support for configuring the Access API token through the environment.
  - Updated tunnel configuration guidance to target the console’s secure Access API port.

- **Documentation**
  - Revised setup instructions to reflect the new API endpoint, authentication method, token usage, and deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->