### PR TITLE
Fix adding a second license plate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,8 +204,12 @@ account at `/members/vehicles` (used for License Plate Unlock at the gate).
     credential_status}`. The plate number is `credential`; `id` is the
     credential UUID needed to unassign it.
   - **Assign** (§3.28) `PUT /users/:id/license_plates` — body is a **bare
-    JSON array of plate strings**, not a wrapped object, and PUT *replaces*
-    the collection, so send the full desired set.
+    JSON array of plate strings**, not a wrapped object. Despite the PUT
+    verb it *adds* rather than replaces: each string becomes a credential,
+    and the request is rejected if any plate is already registered (plates
+    are unique across Access). Send only the plates being added, never the
+    existing set — re-sending an existing plate is what blocked adding a
+    second one. Removal is per-credential via the DELETE below.
   - **Unassign** (§3.29) `DELETE /users/:id/license_plates/:plate_id`.
   - License plate endpoints need **UniFi Access 3.3.10 or later**.
 - `src/pages/members/vehicles.astro` — SSR page listing plates with

--- a/src/lib/unifi.ts
+++ b/src/lib/unifi.ts
@@ -559,8 +559,12 @@ export async function getLicensePlates(
 
 /**
  * Assigns license plates to a user (spec 3.28). The body is a bare JSON
- * array of plate strings, and PUT replaces the collection — so callers
- * must pass the full desired set, not just the new plate.
+ * array of plate strings. Despite being a PUT, this *adds* credentials
+ * rather than replacing the collection: each string becomes a new
+ * credential, and the request is rejected outright if any plate is already
+ * registered (a plate is unique across Access). Pass only the plates being
+ * added — never the existing set, or the already-registered ones collide.
+ * Removal is per-credential via {@link unassignLicensePlate}.
  */
 export async function assignLicensePlates(
   env: UnifiEnv,

--- a/src/pages/api/members/vehicles.ts
+++ b/src/pages/api/members/vehicles.ts
@@ -69,11 +69,11 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
       if (existing.length >= MAX_PLATES_PER_USER) {
         return redirect(back("limit"), 303);
       }
-      // PUT replaces the collection, so send the full desired set.
-      await assignLicensePlates(env, user.id, [
-        ...existing.map((entry) => entry.plate),
-        input.plate,
-      ]);
+      // The PUT registers a credential for each plate in the array and
+      // rejects the whole request if any plate is already registered — so
+      // send only the new one, never the existing set. (Re-sending the
+      // existing plates is exactly what blocked adding a second plate.)
+      await assignLicensePlates(env, user.id, [input.plate]);
       return redirect(back("added"), 303);
     }
 


### PR DESCRIPTION
Adding a second license plate always failed. (First plates worked — which also confirms the Open-API connection from #84 is now live.)

## Cause

The add handler sent the **full desired collection** on assign — existing plates plus the new one — on the assumption that `PUT /users/:id/license_plates` *replaces* the collection.

It doesn't. Despite the PUT verb, the endpoint registers a credential for each string in the array and **rejects the entire request if any plate is already registered** (a plate is unique across Access). So the second add sent `[first, second]`, the console refused it because `first` already existed, and nothing was added.

The tell that this was never replace-semantics: the API has a dedicated per-credential `DELETE` (spec §3.29). A collection-replacing PUT would have no need for one — you'd just PUT the smaller set. And the clincher is the bug itself: under replace-semantics, re-sending `[first, second]` would have *worked*.

## Fix

Assign now sends only the plate being added — `[newPlate]`. Existing plates are untouched because the call never mentions them. Removal already used the per-credential DELETE, so it was correct and is unchanged.

```diff
-      // PUT replaces the collection, so send the full desired set.
-      await assignLicensePlates(env, user.id, [
-        ...existing.map((entry) => entry.plate),
-        input.plate,
-      ]);
+      await assignLicensePlates(env, user.id, [input.plate]);
```

The `assignLicensePlates` docstring and the `AGENTS.md` §3.28 note are corrected to describe additive semantics, since both previously stated the wrong "replace" model.

## Verification

`tsc --noEmit` and `astro build` clean. Stubbed console confirms the add PUTs a bare `[newPlate]` to `/users/:id/license_plates` and never resends an existing plate.

Not exercised against the live console from CI, but this directly matches the observed failure and the §3.29 evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bp5FYFyTpUmodzipjWRu)_